### PR TITLE
small code improvements in aura api.go

### DIFF
--- a/common/clicfg/clicfg.go
+++ b/common/clicfg/clicfg.go
@@ -35,6 +35,14 @@ func (config *Config) Get(key string) (interface{}, error) {
 	return val, nil
 }
 
+func (config *Config) GetString(key string) (string, error) {
+	if !config.viper.IsSet(key) {
+		return "", fmt.Errorf("could not find config value with key %s", key)
+	}
+
+	return config.viper.GetString(key), nil
+}
+
 func (config *Config) Set(key string, value interface{}) error {
 	config.viper.Set(key, value)
 

--- a/neo4j/aura/internal/api/api.go
+++ b/neo4j/aura/internal/api/api.go
@@ -37,106 +37,6 @@ type ServerError struct {
 	Error string `json:"error"`
 }
 
-func getToken(ctx context.Context) (string, error) {
-	config, ok := clictx.Config(ctx)
-	if !ok {
-		return "", errors.New("error fetching cli configuration values")
-	}
-
-	credential, err := config.Aura.GetDefaultCredential()
-	if err != nil {
-		return "", err
-	}
-
-	if credential.IsAccessTokenValid() {
-		return credential.AccessToken, nil
-	}
-
-	data := url.Values{}
-
-	data.Set("grant_type", "client_credentials")
-
-	u, err := config.Get("aura.auth-url")
-
-	if err != nil {
-		return "", err
-	}
-
-	req, err := http.NewRequest("POST", u.(string), strings.NewReader(data.Encode()))
-
-	if err != nil {
-		return "", err
-	}
-
-	version, ok := clictx.Version(ctx)
-	if !ok {
-		return "", errors.New("error fetching version from context")
-	}
-
-	req.Header = http.Header{
-		"Content-Type": {"application/x-www-form-urlencoded"},
-		"User-Agent":   {fmt.Sprintf(userAgent, version)},
-	}
-	req.SetBasicAuth(credential.ClientId, credential.ClientSecret)
-
-	client := http.Client{}
-
-	res, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-
-	switch statusCode := res.StatusCode; statusCode {
-	case http.StatusBadRequest:
-		return "", errors.New("request is invalid")
-	case http.StatusUnauthorized:
-		return "", errors.New("the provided credentials are invalid, expired, or revoked")
-	case http.StatusForbidden:
-		return "", errors.New("the request body is invalid")
-	case http.StatusNotFound:
-		return "", errors.New("the request body is missing")
-	}
-
-	defer res.Body.Close()
-
-	resBody, err := io.ReadAll(res.Body)
-
-	if err != nil {
-		return "", err
-	}
-
-	var grant Grant
-
-	err = json.Unmarshal(resBody, &grant)
-
-	if err != nil {
-		return "", err
-	}
-
-	credential.UpdateAccessToken(grant.AccessToken, grant.ExpiresIn)
-	config.Write()
-	return grant.AccessToken, nil
-}
-
-func getHeaders(ctx context.Context) (http.Header, error) {
-	token, err := getToken(ctx)
-
-	if err != nil {
-		return nil, err
-	}
-
-	version, ok := clictx.Version(ctx)
-	if !ok {
-		return nil, errors.New("error fetching version from context")
-	}
-
-	return http.Header{
-		"Content-Type":  {"application/json"},
-		"Authorization": {fmt.Sprintf("Bearer %s", token)},
-		"User-Agent":    {fmt.Sprintf(userAgent, version)},
-	}, nil
-}
-
 func MakeRequest(cmd *cobra.Command, method string, path string, data map[string]any) error {
 	cmd.SilenceUsage = true
 
@@ -160,12 +60,12 @@ func MakeRequest(cmd *cobra.Command, method string, path string, data map[string
 		return errors.New("error fetching cli configuration values")
 	}
 
-	baseUrl, err := config.Get("aura.base-url")
+	baseUrl, err := config.GetString("aura.base-url")
 	if err != nil {
 		return err
 	}
 
-	u, _ := url.ParseRequestURI(baseUrl.(string))
+	u, _ := url.ParseRequestURI(baseUrl)
 	u = u.JoinPath(path)
 	urlString := u.String()
 
@@ -189,24 +89,28 @@ func MakeRequest(cmd *cobra.Command, method string, path string, data map[string
 
 	defer res.Body.Close()
 
+	output, err := config.GetString("aura.output")
+	if err != nil {
+		return err
+	}
+
+	return handleResponse(cmd, res, output)
+}
+
+func handleResponse(cmd *cobra.Command, res *http.Response, outputType string) error {
+	var err error
 	resBody, err := io.ReadAll(res.Body)
 
 	if err != nil {
 		return err
 	}
 
-	output, err := config.Get("aura.output")
-	if err != nil {
-		return err
-	}
-
 	switch statusCode := res.StatusCode; statusCode {
+
 	// successful responses
-	case http.StatusOK:
-		fallthrough
-	case http.StatusAccepted:
+	case http.StatusAccepted, http.StatusOK:
 		if len(resBody) > 0 {
-			switch output := output.(string); output {
+			switch output := outputType; output {
 			case "json":
 				var pretty bytes.Buffer
 				err := json.Indent(&pretty, resBody, "", "\t")
@@ -324,13 +228,7 @@ func MakeRequest(cmd *cobra.Command, method string, path string, data map[string
 		retryAfter := res.Header.Get("Retry-After")
 		return fmt.Errorf("server rate limit exceeded, suggested cool-off period is %s seconds before rerunning the command", retryAfter)
 	// server error responses
-	case http.StatusInternalServerError:
-		fallthrough
-	case http.StatusBadGateway:
-		fallthrough
-	case http.StatusServiceUnavailable:
-		fallthrough
-	case http.StatusGatewayTimeout:
+	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
 		var errorResponse ErrorResponse
 
 		err = json.Unmarshal(resBody, &errorResponse)
@@ -349,4 +247,103 @@ func MakeRequest(cmd *cobra.Command, method string, path string, data map[string
 	}
 
 	return nil
+}
+
+func getHeaders(ctx context.Context) (http.Header, error) {
+	token, err := getToken(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	version, ok := clictx.Version(ctx)
+	if !ok {
+		return nil, errors.New("error fetching version from context")
+	}
+
+	return http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", token)},
+		"User-Agent":    {fmt.Sprintf(userAgent, version)},
+	}, nil
+}
+
+func getToken(ctx context.Context) (string, error) {
+	config, ok := clictx.Config(ctx)
+	if !ok {
+		return "", errors.New("error fetching cli configuration values")
+	}
+
+	credential, err := config.Aura.GetDefaultCredential()
+	if err != nil {
+		return "", err
+	}
+
+	if credential.IsAccessTokenValid() {
+		return credential.AccessToken, nil
+	}
+
+	data := url.Values{}
+
+	data.Set("grant_type", "client_credentials")
+
+	url, err := config.GetString("aura.auth-url")
+
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", url, strings.NewReader(data.Encode()))
+
+	if err != nil {
+		return "", err
+	}
+
+	version, ok := clictx.Version(ctx)
+	if !ok {
+		return "", errors.New("error fetching version from context")
+	}
+
+	req.Header = http.Header{
+		"Content-Type": {"application/x-www-form-urlencoded"},
+		"User-Agent":   {fmt.Sprintf(userAgent, version)},
+	}
+	req.SetBasicAuth(credential.ClientId, credential.ClientSecret)
+
+	client := http.Client{}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	switch statusCode := res.StatusCode; statusCode {
+	case http.StatusBadRequest:
+		return "", errors.New("request is invalid")
+	case http.StatusUnauthorized:
+		return "", errors.New("the provided credentials are invalid, expired, or revoked")
+	case http.StatusForbidden:
+		return "", errors.New("the request body is invalid")
+	case http.StatusNotFound:
+		return "", errors.New("the request body is missing")
+	}
+
+	resBody, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		return "", err
+	}
+
+	var grant Grant
+
+	err = json.Unmarshal(resBody, &grant)
+
+	if err != nil {
+		return "", err
+	}
+
+	credential.UpdateAccessToken(grant.AccessToken, grant.ExpiresIn)
+	config.Write()
+	return grant.AccessToken, nil
 }


### PR DESCRIPTION
A small cleanup of `api.go`:

* Add method `GetString` to `clicfg`, this seems to be in line to how viper works and simplifies a little bit the config usage in the most common use case we have
* splits `MakeRequest`, with the response handling in a separate method, purely to reduce the code complexity of MakeRequest
* Change `fallthrough` to multiple elements in the case statement, which seems a bit less brittle, as reordering the case statements could cause a statement to fallthrough to the wrong case