### PR TITLE
Split make request api and output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ go.work.sum
 .env
 
 bin/
+
+test-api/

--- a/neo4j/aura/internal/api/api.go
+++ b/neo4j/aura/internal/api/api.go
@@ -2,15 +2,11 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
-	"strings"
 
 	"github.com/neo4j/cli/common/clictx"
 	"github.com/spf13/cobra"
@@ -23,21 +19,7 @@ type Grant struct {
 	ExpiresIn   int64  `json:"expires_in"`
 }
 
-type ErrorResponse struct {
-	Errors []Error `json:"errors"`
-}
-
-type Error struct {
-	Message string `json:"message"`
-	Reason  string `json:"reason"`
-	Field   string `json:"field"`
-}
-
-type ServerError struct {
-	Error string `json:"error"`
-}
-
-func MakeRequest(cmd *cobra.Command, method string, path string, data map[string]any) error {
+func MakeRequest(cmd *cobra.Command, method string, path string, data map[string]any) (responseBody []byte, statusCode int, err error) {
 	cmd.SilenceUsage = true
 
 	client := http.Client{}
@@ -48,7 +30,7 @@ func MakeRequest(cmd *cobra.Command, method string, path string, data map[string
 		jsonData, err := json.Marshal(data)
 
 		if err != nil {
-			return err
+			return responseBody, 0, err
 		}
 
 		body = bytes.NewBuffer(jsonData)
@@ -57,12 +39,12 @@ func MakeRequest(cmd *cobra.Command, method string, path string, data map[string
 	config, ok := clictx.Config(cmd.Context())
 
 	if !ok {
-		return errors.New("error fetching cli configuration values")
+		return responseBody, 0, errors.New("error fetching cli configuration values")
 	}
 
 	baseUrl, err := config.GetString("aura.base-url")
 	if err != nil {
-		return err
+		return responseBody, 0, err
 	}
 
 	u, _ := url.ParseRequestURI(baseUrl)
@@ -72,278 +54,35 @@ func MakeRequest(cmd *cobra.Command, method string, path string, data map[string
 	req, err := http.NewRequest(method, urlString, body)
 
 	if err != nil {
-		return err
+		return responseBody, 0, err
 	}
 
 	req.Header, err = getHeaders(cmd.Context())
-
 	if err != nil {
-		return err
+		return responseBody, 0, err
 	}
 
 	res, err := client.Do(req)
-
 	if err != nil {
-		return err
+		return responseBody, 0, err
 	}
 
 	defer res.Body.Close()
 
-	output, err := config.GetString("aura.output")
-	if err != nil {
-		return err
+	if isSuccessful(res.StatusCode) {
+		responseBody, err = io.ReadAll(res.Body)
+
+		if err != nil {
+			return responseBody, 0, err
+		}
+
+		return responseBody, res.StatusCode, nil
 	}
 
-	return handleResponse(cmd, res, output)
+	return responseBody, res.StatusCode, handleResponseError(res)
 }
 
-func handleResponse(cmd *cobra.Command, res *http.Response, outputType string) error {
-	var err error
-	resBody, err := io.ReadAll(res.Body)
-
-	if err != nil {
-		return err
-	}
-
-	switch statusCode := res.StatusCode; statusCode {
-
-	// successful responses
-	case http.StatusAccepted, http.StatusOK:
-		if len(resBody) > 0 {
-			switch output := outputType; output {
-			case "json":
-				var pretty bytes.Buffer
-				err := json.Indent(&pretty, resBody, "", "\t")
-				if err != nil {
-					return err
-				}
-				cmd.Println(pretty.String())
-			default:
-				cmd.Println(string(resBody))
-			}
-		}
-	case http.StatusNoContent:
-		cmd.Println("Operation Successful")
-	// redirection messages
-	case http.StatusPermanentRedirect:
-		return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
-	// client error responses
-	case http.StatusBadRequest:
-		var errorResponse ErrorResponse
-
-		err = json.Unmarshal(resBody, &errorResponse)
-		if err != nil {
-			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
-		}
-
-		messages := []string{}
-		for _, e := range errorResponse.Errors {
-			messages = append(messages, e.Message)
-		}
-
-		return fmt.Errorf("%s", messages)
-	case http.StatusUnauthorized:
-		// TODO: clear the token?
-		var errorResponse ErrorResponse
-
-		err = json.Unmarshal(resBody, &errorResponse)
-		if err != nil {
-			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
-		}
-
-		messages := []string{}
-		for _, e := range errorResponse.Errors {
-			messages = append(messages, e.Message)
-		}
-
-		return fmt.Errorf("%s", messages)
-	case http.StatusForbidden:
-		var serverError ServerError
-
-		err := json.Unmarshal(resBody, &serverError)
-
-		if err != nil {
-			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
-		}
-
-		// TODO: clear the token?
-		var errorResponse ErrorResponse
-
-		err = json.Unmarshal(resBody, &errorResponse)
-		if err != nil {
-			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
-		}
-
-		messages := []string{}
-		for _, e := range errorResponse.Errors {
-			messages = append(messages, e.Message)
-		}
-
-		return fmt.Errorf("%s", messages)
-	case http.StatusNotFound:
-		var errorResponse ErrorResponse
-
-		err = json.Unmarshal(resBody, &errorResponse)
-		if err != nil {
-			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
-		}
-
-		messages := []string{}
-		for _, e := range errorResponse.Errors {
-			messages = append(messages, e.Message)
-		}
-
-		return fmt.Errorf("%s", messages)
-	case http.StatusMethodNotAllowed:
-		var errorResponse ErrorResponse
-
-		err = json.Unmarshal(resBody, &errorResponse)
-		if err != nil {
-			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
-		}
-
-		messages := []string{}
-		for _, e := range errorResponse.Errors {
-			messages = append(messages, e.Message)
-		}
-
-		return fmt.Errorf("%s", messages)
-	case http.StatusConflict:
-		var errorResponse ErrorResponse
-
-		err = json.Unmarshal(resBody, &errorResponse)
-		if err != nil {
-			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
-		}
-
-		messages := []string{}
-		for _, e := range errorResponse.Errors {
-			messages = append(messages, e.Message)
-		}
-
-		return fmt.Errorf("%s", messages)
-	case http.StatusUnsupportedMediaType:
-		return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
-	case http.StatusTooManyRequests:
-		retryAfter := res.Header.Get("Retry-After")
-		return fmt.Errorf("server rate limit exceeded, suggested cool-off period is %s seconds before rerunning the command", retryAfter)
-	// server error responses
-	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
-		var errorResponse ErrorResponse
-
-		err = json.Unmarshal(resBody, &errorResponse)
-		if err != nil {
-			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
-		}
-
-		messages := []string{}
-		for _, e := range errorResponse.Errors {
-			messages = append(messages, e.Message)
-		}
-
-		return fmt.Errorf("%s", messages)
-	default:
-		return fmt.Errorf("unexpected status code %d and body %s running CLI with args %s, please report an issue in https://github.com/neo4j/cli", statusCode, resBody, os.Args[1:])
-	}
-
-	return nil
-}
-
-func getHeaders(ctx context.Context) (http.Header, error) {
-	token, err := getToken(ctx)
-
-	if err != nil {
-		return nil, err
-	}
-
-	version, ok := clictx.Version(ctx)
-	if !ok {
-		return nil, errors.New("error fetching version from context")
-	}
-
-	return http.Header{
-		"Content-Type":  {"application/json"},
-		"Authorization": {fmt.Sprintf("Bearer %s", token)},
-		"User-Agent":    {fmt.Sprintf(userAgent, version)},
-	}, nil
-}
-
-func getToken(ctx context.Context) (string, error) {
-	config, ok := clictx.Config(ctx)
-	if !ok {
-		return "", errors.New("error fetching cli configuration values")
-	}
-
-	credential, err := config.Aura.GetDefaultCredential()
-	if err != nil {
-		return "", err
-	}
-
-	if credential.IsAccessTokenValid() {
-		return credential.AccessToken, nil
-	}
-
-	data := url.Values{}
-
-	data.Set("grant_type", "client_credentials")
-
-	url, err := config.GetString("aura.auth-url")
-
-	if err != nil {
-		return "", err
-	}
-
-	req, err := http.NewRequest("POST", url, strings.NewReader(data.Encode()))
-
-	if err != nil {
-		return "", err
-	}
-
-	version, ok := clictx.Version(ctx)
-	if !ok {
-		return "", errors.New("error fetching version from context")
-	}
-
-	req.Header = http.Header{
-		"Content-Type": {"application/x-www-form-urlencoded"},
-		"User-Agent":   {fmt.Sprintf(userAgent, version)},
-	}
-	req.SetBasicAuth(credential.ClientId, credential.ClientSecret)
-
-	client := http.Client{}
-
-	res, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer res.Body.Close()
-
-	switch statusCode := res.StatusCode; statusCode {
-	case http.StatusBadRequest:
-		return "", errors.New("request is invalid")
-	case http.StatusUnauthorized:
-		return "", errors.New("the provided credentials are invalid, expired, or revoked")
-	case http.StatusForbidden:
-		return "", errors.New("the request body is invalid")
-	case http.StatusNotFound:
-		return "", errors.New("the request body is missing")
-	}
-
-	resBody, err := io.ReadAll(res.Body)
-
-	if err != nil {
-		return "", err
-	}
-
-	var grant Grant
-
-	err = json.Unmarshal(resBody, &grant)
-
-	if err != nil {
-		return "", err
-	}
-
-	credential.UpdateAccessToken(grant.AccessToken, grant.ExpiresIn)
-	config.Write()
-	return grant.AccessToken, nil
+// Checks status code is 2xx
+func isSuccessful(statusCode int) bool {
+	return statusCode >= 200 && statusCode <= 299
 }

--- a/neo4j/aura/internal/api/response.go
+++ b/neo4j/aura/internal/api/response.go
@@ -1,0 +1,178 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/neo4j/cli/common/clictx"
+)
+
+type ErrorResponse struct {
+	Errors []Error `json:"errors"`
+}
+
+type Error struct {
+	Message string `json:"message"`
+	Reason  string `json:"reason"`
+	Field   string `json:"field"`
+}
+
+type ServerError struct {
+	Error string `json:"error"`
+}
+
+func handleResponseError(res *http.Response) error {
+	var err error
+	resBody, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		return err
+	}
+
+	switch statusCode := res.StatusCode; statusCode {
+	// redirection messages
+	case http.StatusPermanentRedirect:
+		return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
+	// client error responses
+	case http.StatusBadRequest:
+		var errorResponse ErrorResponse
+
+		err = json.Unmarshal(resBody, &errorResponse)
+		if err != nil {
+			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
+		}
+
+		messages := []string{}
+		for _, e := range errorResponse.Errors {
+			messages = append(messages, e.Message)
+		}
+
+		return fmt.Errorf("%s", messages)
+	case http.StatusUnauthorized:
+		// TODO: clear the token?
+		var errorResponse ErrorResponse
+
+		err = json.Unmarshal(resBody, &errorResponse)
+		if err != nil {
+			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
+		}
+
+		messages := []string{}
+		for _, e := range errorResponse.Errors {
+			messages = append(messages, e.Message)
+		}
+
+		return fmt.Errorf("%s", messages)
+	case http.StatusForbidden:
+		var serverError ServerError
+
+		err := json.Unmarshal(resBody, &serverError)
+
+		if err != nil {
+			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
+		}
+
+		// TODO: clear the token?
+		var errorResponse ErrorResponse
+
+		err = json.Unmarshal(resBody, &errorResponse)
+		if err != nil {
+			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
+		}
+
+		messages := []string{}
+		for _, e := range errorResponse.Errors {
+			messages = append(messages, e.Message)
+		}
+
+		return fmt.Errorf("%s", messages)
+	case http.StatusNotFound:
+		var errorResponse ErrorResponse
+
+		err = json.Unmarshal(resBody, &errorResponse)
+		if err != nil {
+			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
+		}
+
+		messages := []string{}
+		for _, e := range errorResponse.Errors {
+			messages = append(messages, e.Message)
+		}
+
+		return fmt.Errorf("%s", messages)
+	case http.StatusMethodNotAllowed:
+		var errorResponse ErrorResponse
+
+		err = json.Unmarshal(resBody, &errorResponse)
+		if err != nil {
+			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
+		}
+
+		messages := []string{}
+		for _, e := range errorResponse.Errors {
+			messages = append(messages, e.Message)
+		}
+
+		return fmt.Errorf("%s", messages)
+	case http.StatusConflict:
+		var errorResponse ErrorResponse
+
+		err = json.Unmarshal(resBody, &errorResponse)
+		if err != nil {
+			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
+		}
+
+		messages := []string{}
+		for _, e := range errorResponse.Errors {
+			messages = append(messages, e.Message)
+		}
+
+		return fmt.Errorf("%s", messages)
+	case http.StatusUnsupportedMediaType:
+		return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
+	case http.StatusTooManyRequests:
+		retryAfter := res.Header.Get("Retry-After")
+		return fmt.Errorf("server rate limit exceeded, suggested cool-off period is %s seconds before rerunning the command", retryAfter)
+	// server error responses
+	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		var errorResponse ErrorResponse
+
+		err = json.Unmarshal(resBody, &errorResponse)
+		if err != nil {
+			return fmt.Errorf("unexpected error running CLI with args %s, please report an issue in https://github.com/neo4j/cli", os.Args[1:])
+		}
+
+		messages := []string{}
+		for _, e := range errorResponse.Errors {
+			messages = append(messages, e.Message)
+		}
+
+		return fmt.Errorf("%s", messages)
+	default:
+		return fmt.Errorf("unexpected status code %d and body %s running CLI with args %s, please report an issue in https://github.com/neo4j/cli", statusCode, resBody, os.Args[1:])
+	}
+}
+
+func getHeaders(ctx context.Context) (http.Header, error) {
+	token, err := getToken(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	version, ok := clictx.Version(ctx)
+	if !ok {
+		return nil, errors.New("error fetching version from context")
+	}
+
+	return http.Header{
+		"Content-Type":  {"application/json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", token)},
+		"User-Agent":    {fmt.Sprintf(userAgent, version)},
+	}, nil
+}

--- a/neo4j/aura/internal/api/token.go
+++ b/neo4j/aura/internal/api/token.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/neo4j/cli/common/clictx"
+)
+
+func getToken(ctx context.Context) (string, error) {
+	config, ok := clictx.Config(ctx)
+	if !ok {
+		return "", errors.New("error fetching cli configuration values")
+	}
+
+	credential, err := config.Aura.GetDefaultCredential()
+	if err != nil {
+		return "", err
+	}
+
+	if credential.IsAccessTokenValid() {
+		return credential.AccessToken, nil
+	}
+
+	data := url.Values{}
+
+	data.Set("grant_type", "client_credentials")
+
+	url, err := config.GetString("aura.auth-url")
+
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", err
+	}
+
+	version, ok := clictx.Version(ctx)
+	if !ok {
+		return "", errors.New("error fetching version from context")
+	}
+
+	req.Header = http.Header{
+		"Content-Type": {"application/x-www-form-urlencoded"},
+		"User-Agent":   {fmt.Sprintf(userAgent, version)},
+	}
+	req.SetBasicAuth(credential.ClientId, credential.ClientSecret)
+
+	client := http.Client{}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	switch statusCode := res.StatusCode; statusCode {
+	case http.StatusBadRequest:
+		return "", errors.New("request is invalid")
+	case http.StatusUnauthorized:
+		return "", errors.New("the provided credentials are invalid, expired, or revoked")
+	case http.StatusForbidden:
+		return "", errors.New("the request body is invalid")
+	case http.StatusNotFound:
+		return "", errors.New("the request body is missing")
+	}
+
+	resBody, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		return "", err
+	}
+
+	var grant Grant
+
+	err = json.Unmarshal(resBody, &grant)
+
+	if err != nil {
+		return "", err
+	}
+
+	credential.UpdateAccessToken(grant.AccessToken, grant.ExpiresIn)
+	config.Write()
+	return grant.AccessToken, nil
+}

--- a/neo4j/aura/internal/output/output.go
+++ b/neo4j/aura/internal/output/output.go
@@ -1,0 +1,39 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+
+	"github.com/neo4j/cli/common/clictx"
+	"github.com/spf13/cobra"
+)
+
+// Prints a response body
+func PrintBody(cmd *cobra.Command, body []byte) error {
+	config, ok := clictx.Config(cmd.Context())
+	if !ok {
+		return errors.New("error fetching cli configuration values")
+	}
+
+	outputType, err := config.GetString("aura.output")
+	if err != nil {
+		return err
+	}
+
+	if len(body) > 0 {
+		switch output := outputType; output {
+		case "json":
+			var pretty bytes.Buffer
+			err := json.Indent(&pretty, body, "", "\t")
+			if err != nil {
+				return err
+			}
+			cmd.Println(pretty.String())
+		default:
+			cmd.Println(string(body))
+		}
+	}
+
+	return nil
+}

--- a/neo4j/aura/internal/subcommands/customermanagedkey/create.go
+++ b/neo4j/aura/internal/subcommands/customermanagedkey/create.go
@@ -2,9 +2,11 @@ package customermanagedkey
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/neo4j/cli/common/clictx"
 	"github.com/neo4j/cli/neo4j/aura/internal/api"
+	"github.com/neo4j/cli/neo4j/aura/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -68,7 +70,21 @@ Once the key has a status of ready you can use it for creating new instances by 
 				body["tenant_id"] = tenantId
 			}
 
-			return api.MakeRequest(cmd, "POST", "/customer-managed-keys", body)
+			resBody, statusCode, err := api.MakeRequest(cmd, http.MethodPost, "/customer-managed-keys", body)
+			if err != nil {
+				return err
+			}
+			// NOTE: Instance delete should not return OK (200), it always returns 202
+			if statusCode == http.StatusAccepted || statusCode == http.StatusOK {
+				err = output.PrintBody(cmd, resBody)
+				if err != nil {
+					return err
+				}
+
+			}
+
+			return nil
+
 		},
 	}
 

--- a/neo4j/aura/internal/subcommands/customermanagedkey/delete.go
+++ b/neo4j/aura/internal/subcommands/customermanagedkey/delete.go
@@ -2,6 +2,7 @@ package customermanagedkey
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/neo4j/cli/neo4j/aura/internal/api"
 	"github.com/spf13/cobra"
@@ -16,7 +17,18 @@ func NewDeleteCmd() *cobra.Command {
 Note that you can only delete a Key if it is not being used by any instances, otherwise you will get an error with the reason field set to encryption-key-is-active.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return api.MakeRequest(cmd, "DELETE", fmt.Sprintf("/customer-managed-keys/%s", args[0]), nil)
+			path := fmt.Sprintf("/customer-managed-keys/%s", args[0])
+			_, statusCode, err := api.MakeRequest(cmd, http.MethodDelete, path, nil)
+			if err != nil {
+				return err
+			}
+
+			if statusCode == http.StatusNoContent {
+				cmd.Println("Operation Successful")
+
+			}
+
+			return nil
 		},
 	}
 }

--- a/neo4j/aura/internal/subcommands/customermanagedkey/get.go
+++ b/neo4j/aura/internal/subcommands/customermanagedkey/get.go
@@ -2,8 +2,10 @@ package customermanagedkey
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/neo4j/cli/neo4j/aura/internal/api"
+	"github.com/neo4j/cli/neo4j/aura/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +16,18 @@ func NewGetCmd() *cobra.Command {
 		Long:  `This subcommand returns details about a specific Customer Managed Key.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return api.MakeRequest(cmd, "GET", fmt.Sprintf("/customer-managed-keys/%s", args[0]), nil)
+			path := fmt.Sprintf("/customer-managed-keys/%s", args[0])
+			resBody, statusCode, err := api.MakeRequest(cmd, http.MethodGet, path, nil)
+			if err != nil {
+				return err
+			}
+
+			if statusCode == http.StatusOK {
+				output.PrintBody(cmd, resBody)
+
+			}
+
+			return nil
 		},
 	}
 }

--- a/neo4j/aura/internal/subcommands/customermanagedkey/list.go
+++ b/neo4j/aura/internal/subcommands/customermanagedkey/list.go
@@ -2,8 +2,10 @@ package customermanagedkey
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/neo4j/cli/neo4j/aura/internal/api"
+	"github.com/neo4j/cli/neo4j/aura/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +20,25 @@ func NewListCmd() *cobra.Command {
 You can filter keys in a particular tenant using --tenant-id. If the tenant flag is not specified, this endpoint lists all keys a user has access to across all tenants.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			var path string
+
 			if tenantId != "" {
-				return api.MakeRequest(cmd, "GET", fmt.Sprintf("/customer-managed-keys?tenantId=%s", tenantId), nil)
+				path = fmt.Sprintf("/customer-managed-keys?tenantId=%s", tenantId)
 			} else {
-				return api.MakeRequest(cmd, "GET", "/customer-managed-keys", nil)
+				path = "/customer-managed-keys"
 			}
+
+			resBody, statusCode, err := api.MakeRequest(cmd, http.MethodGet, path, nil)
+			if err != nil {
+				return err
+			}
+
+			if statusCode == http.StatusOK {
+				output.PrintBody(cmd, resBody)
+
+			}
+
+			return nil
 		},
 	}
 

--- a/neo4j/aura/internal/subcommands/instance/create.go
+++ b/neo4j/aura/internal/subcommands/instance/create.go
@@ -2,9 +2,11 @@ package instance
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/neo4j/cli/common/clictx"
 	"github.com/neo4j/cli/neo4j/aura/internal/api"
+	"github.com/neo4j/cli/neo4j/aura/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -92,7 +94,21 @@ For Enterprise instances you can specify a --customer-managed-key-id flag to use
 				body["customer_managed_key_id"] = customerManagedKeyId
 			}
 
-			return api.MakeRequest(cmd, "POST", "/instances", body)
+			resBody, statusCode, err := api.MakeRequest(cmd, http.MethodPost, "/instances", body)
+			if err != nil {
+				return err
+			}
+
+			// NOTE: Instance create should not return OK (200), it always returns 202
+			if statusCode == http.StatusAccepted || statusCode == http.StatusOK {
+				err = output.PrintBody(cmd, resBody)
+				if err != nil {
+					return err
+				}
+
+			}
+
+			return nil
 		},
 	}
 

--- a/neo4j/aura/internal/subcommands/instance/create_test.go
+++ b/neo4j/aura/internal/subcommands/instance/create_test.go
@@ -21,7 +21,7 @@ func TestCreateFreeInstance(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()
 
-	mockHandler := helper.NewRequestHandlerMock("/v1/instances", http.StatusOK, `{
+	mockHandler := helper.NewRequestHandlerMock("/v1/instances", http.StatusAccepted, `{
 			"data": {
 				"id": "db1d1234",
 				"connection_url": "YOUR_CONNECTION_URL",
@@ -60,7 +60,7 @@ func TestCreateProfessionalInstance(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()
 
-	mockHandler := helper.NewRequestHandlerMock("/v1/instances", http.StatusOK, `{
+	mockHandler := helper.NewRequestHandlerMock("/v1/instances", http.StatusAccepted, `{
 			"data": {
 				"id": "db1d1234",
 				"connection_url": "YOUR_CONNECTION_URL",
@@ -259,7 +259,7 @@ func TestInstanceWithCmkId(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()
 
-	mockHandler := helper.NewRequestHandlerMock("/v1/instances", http.StatusOK, `{
+	mockHandler := helper.NewRequestHandlerMock("/v1/instances", http.StatusAccepted, `{
 			"data": {
 				"id": "db1d1234",
 				"connection_url": "YOUR_CONNECTION_URL",
@@ -310,7 +310,7 @@ func TestCreateFreeInstanceWithConfigTenantId(t *testing.T) {
 		}
 	}`)
 
-	mockHandler := helper.NewRequestHandlerMock("/v1/instances", http.StatusOK, `{
+	mockHandler := helper.NewRequestHandlerMock("/v1/instances", http.StatusAccepted, `{
 			"data": {
 				"id": "db1d1234",
 				"connection_url": "YOUR_CONNECTION_URL",

--- a/neo4j/aura/internal/subcommands/instance/get.go
+++ b/neo4j/aura/internal/subcommands/instance/get.go
@@ -2,8 +2,10 @@ package instance
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/neo4j/cli/neo4j/aura/internal/api"
+	"github.com/neo4j/cli/neo4j/aura/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +16,22 @@ func NewGetCmd() *cobra.Command {
 		Long:  "This endpoint returns details about a specific Aura Instance.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return api.MakeRequest(cmd, "GET", fmt.Sprintf("/instances/%s", args[0]), nil)
+			path := fmt.Sprintf("/instances/%s", args[0])
+
+			resBody, statusCode, err := api.MakeRequest(cmd, http.MethodGet, path, nil)
+			if err != nil {
+				return err
+			}
+
+			if statusCode == http.StatusOK {
+				err = output.PrintBody(cmd, resBody)
+				if err != nil {
+					return err
+				}
+
+			}
+
+			return nil
 		},
 	}
 }

--- a/neo4j/aura/internal/subcommands/instance/list.go
+++ b/neo4j/aura/internal/subcommands/instance/list.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/neo4j/cli/neo4j/aura/internal/api"
+	"github.com/neo4j/cli/neo4j/aura/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +19,27 @@ func NewListCmd() *cobra.Command {
 
 You can filter instances in a particular tenant using --tenant-id. If the tenant flag is not specified, this subcommand lists all instances a user has access to across all tenants.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			var path string
+
 			if tenantId != "" {
-				return api.MakeRequest(cmd, http.MethodGet, fmt.Sprintf("/instances?tenantId=%s", tenantId), nil)
+				path = fmt.Sprintf("/instances?tenantId=%s", tenantId)
 			} else {
-				return api.MakeRequest(cmd, "GET", "/instances", nil)
+				path = "/instances"
 			}
+
+			resBody, statusCode, err := api.MakeRequest(cmd, http.MethodGet, path, nil)
+			if err != nil {
+				return err
+			}
+
+			if statusCode == http.StatusOK {
+				err = output.PrintBody(cmd, resBody)
+				if err != nil {
+					return err
+				}
+
+			}
+			return nil
 		},
 	}
 

--- a/neo4j/aura/internal/subcommands/instance/pause.go
+++ b/neo4j/aura/internal/subcommands/instance/pause.go
@@ -2,8 +2,10 @@ package instance
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/neo4j/cli/neo4j/aura/internal/api"
+	"github.com/neo4j/cli/neo4j/aura/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +22,22 @@ The pause time depends on the amount of data stored in the instance; larger quan
 If another operation is being performed on the instance you are trying to pause, an error will be returned that indicates that the pause operation cannot be performed.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return api.MakeRequest(cmd, "POST", fmt.Sprintf("/instances/%s/pause", args[0]), nil)
+			path := fmt.Sprintf("/instances/%s/pause", args[0])
+
+			resBody, statusCode, err := api.MakeRequest(cmd, http.MethodPost, path, nil)
+			if err != nil {
+				return err
+			}
+
+			// NOTE: Instance pause should not return OK (200), it always returns 202
+			if statusCode == http.StatusAccepted || statusCode == http.StatusOK {
+				err = output.PrintBody(cmd, resBody)
+				if err != nil {
+					return err
+				}
+
+			}
+			return nil
 		},
 	}
 }

--- a/neo4j/aura/internal/subcommands/instance/resume.go
+++ b/neo4j/aura/internal/subcommands/instance/resume.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/neo4j/cli/neo4j/aura/internal/api"
+	"github.com/neo4j/cli/neo4j/aura/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -19,7 +20,22 @@ Resuming an instance is an asynchronous operation. You can poll the current stat
 If another operation is being performed on the instance you are trying to resume, an error will be returned that indicates that resume cannot be performed.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return api.MakeRequest(cmd, http.MethodPost, fmt.Sprintf("/instances/%s/resume", args[0]), nil)
+			path := fmt.Sprintf("/instances/%s/resume", args[0])
+
+			resBody, statusCode, err := api.MakeRequest(cmd, http.MethodPost, path, nil)
+			if err != nil {
+				return err
+			}
+
+			// NOTE: Instance resume should not return OK (200), it always returns 202
+			if statusCode == http.StatusAccepted || statusCode == http.StatusOK {
+				err = output.PrintBody(cmd, resBody)
+				if err != nil {
+					return err
+				}
+
+			}
+			return nil
 		},
 	}
 }

--- a/neo4j/aura/internal/subcommands/instance/update.go
+++ b/neo4j/aura/internal/subcommands/instance/update.go
@@ -2,8 +2,10 @@ package instance
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/neo4j/cli/neo4j/aura/internal/api"
+	"github.com/neo4j/cli/neo4j/aura/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -36,7 +38,21 @@ Resizing an instance is an asynchronous operation. The instance remains availabl
 				body["name"] = name
 			}
 
-			return api.MakeRequest(cmd, "PATCH", fmt.Sprintf("/instances/%s", args[0]), body)
+			path := fmt.Sprintf("/instances/%s", args[0])
+
+			resBody, statusCode, err := api.MakeRequest(cmd, http.MethodPatch, path, body)
+			if err != nil {
+				return err
+			}
+
+			if statusCode == http.StatusAccepted || statusCode == http.StatusOK {
+				err = output.PrintBody(cmd, resBody)
+				if err != nil {
+					return err
+				}
+
+			}
+			return nil
 		},
 	}
 

--- a/neo4j/aura/internal/subcommands/tenant/get.go
+++ b/neo4j/aura/internal/subcommands/tenant/get.go
@@ -2,8 +2,10 @@ package tenant
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/neo4j/cli/neo4j/aura/internal/api"
+	"github.com/neo4j/cli/neo4j/aura/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +16,22 @@ func NewGetCmd() *cobra.Command {
 		Long:  "This subcommand returns details about a specific Aura Tenant.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return api.MakeRequest(cmd, "GET", fmt.Sprintf("/tenants/%s", args[0]), nil)
+			path := fmt.Sprintf("/tenants/%s", args[0])
+
+			resBody, statusCode, err := api.MakeRequest(cmd, http.MethodGet, path, nil)
+			if err != nil {
+				return err
+			}
+
+			if statusCode == http.StatusOK {
+				err = output.PrintBody(cmd, resBody)
+				if err != nil {
+					return err
+				}
+
+			}
+
+			return nil
 		},
 	}
 }

--- a/neo4j/aura/internal/subcommands/tenant/list.go
+++ b/neo4j/aura/internal/subcommands/tenant/list.go
@@ -1,7 +1,10 @@
 package tenant
 
 import (
+	"net/http"
+
 	"github.com/neo4j/cli/neo4j/aura/internal/api"
+	"github.com/neo4j/cli/neo4j/aura/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +14,20 @@ func NewListCmd() *cobra.Command {
 		Short: "Returns a list of tenants",
 		Long:  "This subcommand returns a list containing a summary of each of your Aura Tenants. To find out more about a specific Tenant, retrieve the details using the get subcommand.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return api.MakeRequest(cmd, "GET", "/tenants", nil)
+			resBody, statusCode, err := api.MakeRequest(cmd, http.MethodGet, "/tenants", nil)
+			if err != nil {
+				return err
+			}
+
+			if statusCode == http.StatusOK {
+				err = output.PrintBody(cmd, resBody)
+				if err != nil {
+					return err
+				}
+
+			}
+
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
* Move successful handling (2xx) of aura api commands to the command itself, rather than the `MakeRequest` utility
* `MakeRequests` returns the body and status code
* Move error handling and getToken to different files
* Fix some mutation tests relying on 200 POST operations instead of 202