### PR TITLE
Fix for getting snapshot detail but not supplying the snapshot id

### DIFF
--- a/neo4j/aura/internal/subcommands/instance/snapshot/get.go
+++ b/neo4j/aura/internal/subcommands/instance/snapshot/get.go
@@ -12,14 +12,17 @@ import (
 
 func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 	var instanceId string
+	var snapshotId string
 
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "Get details of a snapshot",
 		Long:  `This endpoint returns details about a specific snapshot.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println(len(args))
+
 			cmd.SilenceUsage = true
-			path := fmt.Sprintf("/instances/%s/snapshots/%s", instanceId, args[0])
+			path := fmt.Sprintf("/instances/%s/snapshots/%s", instanceId, snapshotId)
 
 			resBody, statusCode, err := api.MakeRequest(cfg, path, &api.RequestConfig{
 				Method: http.MethodGet,
@@ -38,8 +41,10 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&instanceId, "instance-id", "", "The id of the instance to list its snapshots")
+	cmd.Flags().StringVar(&instanceId, "instance-id", "", "The id of the instance with the snapshot")
+	cmd.Flags().StringVar(&snapshotId, "snapshot-id", "", "The id of the snaphost")
 	cmd.MarkFlagRequired("instance-id")
+	cmd.MarkFlagRequired("snapshot-id")
 
 	return cmd
 }


### PR DESCRIPTION
When getting the details of a snapshot for an instance, a panic happens when the snapshot id is not given

`neo4j aura instance snapshot get --instance-id c22b6d6e
Unexpected error running CLI with args [aura instance snapshot get --instance-id c22b6d6e], please report an issue in https://github.com/neo4j/cli

panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0`

The help for this command does not indicate that the snapshot id is required.

This PR adds --snapshot-id along with descriptive words for the help to avoid this situation

`./neo4j aura instance snapshot get                                                                          
Error: required flag(s) "instance-id", "snapshot-id" not set
Usage:
  neo4j aura instance snapshot get [flags]

Flags:
  -h, --help                 help for get
      --instance-id string   The id of the instance with the snapshot
      --snapshot-id string   The id of the snaphost

Global Flags:
      --auth-url string   
      --base-url string   
      --output string
`
