### PR TITLE
Change `tenant` to `project`

### DIFF
--- a/.changes/unreleased/Fixed-20241009-114408.yaml
+++ b/.changes/unreleased/Fixed-20241009-114408.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: '`tenant` has been changed to `project.'
+time: 2024-10-09T11:44:08.216054+01:00

--- a/common/clicfg/clicfg.go
+++ b/common/clicfg/clicfg.go
@@ -49,7 +49,7 @@ func NewConfig(fs afero.Fs, version string) (*Config, error) {
 	return &Config{Version: version, Aura: AuraConfig{viper: Viper, pollingOverride: PollingConfig{
 		MaxRetries: 60,
 		Interval:   20,
-	}, ValidConfigKeys: []string{"auth-url", "base-url", "default-tenant", "output"}}}, nil
+	}, ValidConfigKeys: []string{"auth-url", "base-url", "default-project", "output"}}}, nil
 }
 
 func bindEnvironmentVariables(Viper *viper.Viper) {
@@ -134,8 +134,8 @@ func (config *AuraConfig) BindOutput(flag *pflag.Flag) error {
 	return config.viper.BindPFlag("aura.output", flag)
 }
 
-func (config *AuraConfig) DefaultTenant() string {
-	return config.viper.GetString("aura.default-tenant")
+func (config *AuraConfig) DefaultProject() string {
+	return config.viper.GetString("aura.default-project")
 }
 
 func (config *AuraConfig) DefaultCredential() (*AuraCredential, error) {

--- a/neo4j/aura/aura.go
+++ b/neo4j/aura/aura.go
@@ -11,7 +11,7 @@ import (
 	"github.com/neo4j/cli/neo4j/aura/internal/subcommands/credential"
 	"github.com/neo4j/cli/neo4j/aura/internal/subcommands/customermanagedkey"
 	"github.com/neo4j/cli/neo4j/aura/internal/subcommands/instance"
-	"github.com/neo4j/cli/neo4j/aura/internal/subcommands/tenant"
+	"github.com/neo4j/cli/neo4j/aura/internal/subcommands/project"
 )
 
 func NewCmd(cfg *clicfg.Config) *cobra.Command {
@@ -25,7 +25,7 @@ func NewCmd(cfg *clicfg.Config) *cobra.Command {
 	cmd.AddCommand(credential.NewCmd(cfg))
 	cmd.AddCommand(customermanagedkey.NewCmd(cfg))
 	cmd.AddCommand(instance.NewCmd(cfg))
-	cmd.AddCommand(tenant.NewCmd(cfg))
+	cmd.AddCommand(project.NewCmd(cfg))
 
 	return cmd
 }

--- a/neo4j/aura/internal/subcommands/customermanagedkey/create.go
+++ b/neo4j/aura/internal/subcommands/customermanagedkey/create.go
@@ -15,7 +15,7 @@ func NewCreateCmd(cfg *clicfg.Config) *cobra.Command {
 		region        string
 		name          string
 		instanceType  string
-		tenantId      string
+		projectId     string
 		cloudProvider string
 		keyId         string
 		await         bool
@@ -25,7 +25,7 @@ func NewCreateCmd(cfg *clicfg.Config) *cobra.Command {
 		regionFlag        = "region"
 		nameFlag          = "name"
 		instanceTypeFlag  = "type"
-		tenantIdFlag      = "tenant-id"
+		projectIdFlag     = "project-id"
 		cloudProviderFlag = "cloud-provider"
 		keyIdFlag         = "key-id"
 		awaitFlag         = "await"
@@ -42,8 +42,8 @@ You can poll the current status of this operation by periodically getting the ke
 
 Once the key has a status of ready you can use it for creating new instances by setting the --customer-managed-key-id flag.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if cfg.Aura.DefaultTenant() == "" {
-				cmd.MarkFlagRequired(tenantIdFlag)
+			if cfg.Aura.DefaultProject() == "" {
+				cmd.MarkFlagRequired(projectIdFlag)
 			}
 
 			return nil
@@ -57,10 +57,10 @@ Once the key has a status of ready you can use it for creating new instances by 
 				"key_id":         keyId,
 			}
 
-			if tenantId == "" {
-				body["tenant_id"] = cfg.Aura.DefaultTenant()
+			if projectId == "" {
+				body["tenant_id"] = cfg.Aura.DefaultProject()
 			} else {
-				body["tenant_id"] = tenantId
+				body["tenant_id"] = projectId
 			}
 
 			cmd.SilenceUsage = true
@@ -109,7 +109,7 @@ Once the key has a status of ready you can use it for creating new instances by 
 	cmd.Flags().StringVar(&instanceType, instanceTypeFlag, "", "The type of the instance.")
 	cmd.MarkFlagRequired(instanceTypeFlag)
 
-	cmd.Flags().StringVar(&tenantId, tenantIdFlag, "", "")
+	cmd.Flags().StringVar(&projectId, projectIdFlag, "", "")
 
 	cmd.Flags().StringVar(&cloudProvider, cloudProviderFlag, "", "The cloud provider hosting the instance.")
 	cmd.MarkFlagRequired(cloudProviderFlag)

--- a/neo4j/aura/internal/subcommands/customermanagedkey/create_test.go
+++ b/neo4j/aura/internal/subcommands/customermanagedkey/create_test.go
@@ -25,7 +25,7 @@ func TestCreateCustomerManagedKeys(t *testing.T) {
 		}
 	  }`)
 
-	helper.ExecuteCommand(`customer-managed-key create --region us-west-2 --name "Production Key" --type enterprise-db --tenant-id dontpanic --cloud-provider aws --key-id arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`)
+	helper.ExecuteCommand(`customer-managed-key create --region us-west-2 --name "Production Key" --type enterprise-db --project-id dontpanic --cloud-provider aws --key-id arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`)
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodPost)
@@ -53,11 +53,11 @@ func TestCreateCustomerManagedKeys(t *testing.T) {
 	}`)
 }
 
-func TestCreateCustomerManagedKeysWithTenantIDInConfig(t *testing.T) {
+func TestCreateCustomerManagedKeysWithProjectIDInConfig(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()
 
-	helper.SetConfigValue("aura.default-tenant", "dontpanic")
+	helper.SetConfigValue("aura.default-project", "dontpanic")
 
 	mockHandler := helper.NewRequestHandlerMock("/v1/customer-managed-keys", http.StatusAccepted, `{
 		"data": {
@@ -101,7 +101,7 @@ func TestCreateCustomerManagedKeysWithTenantIDInConfig(t *testing.T) {
 	}`)
 }
 
-func TestCreateCustomerManagedKeysWithoutTenantID(t *testing.T) {
+func TestCreateCustomerManagedKeysWithoutProjectID(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()
 
@@ -123,5 +123,5 @@ func TestCreateCustomerManagedKeysWithoutTenantID(t *testing.T) {
 
 	mockHandler.AssertCalledTimes(0)
 
-	helper.AssertErr("Error: required flag(s) \"tenant-id\" not set\n")
+	helper.AssertErr("Error: required flag(s) \"project-id\" not set\n")
 }

--- a/neo4j/aura/internal/subcommands/customermanagedkey/get_test.go
+++ b/neo4j/aura/internal/subcommands/customermanagedkey/get_test.go
@@ -24,7 +24,7 @@ func TestGetCustomerManagedKey(t *testing.T) {
 					"key_id": "arn:aws:kms:us-east-1:123456789:key/11111-a222-1212-x789-1212f1212f",
 					"region": "us-east-1",
 					"type": "enterprise-db",
-					"tenant_id": "YOUR_TENANT_ID",
+					"tenant_id": "YOUR_PROJECT_ID",
 					"status": "ready"
 				}
 			}`)
@@ -43,7 +43,7 @@ func TestGetCustomerManagedKey(t *testing.T) {
 			"name": "Instance01",
 			"region": "us-east-1",
 			"status": "ready",
-			"tenant_id": "YOUR_TENANT_ID",
+			"tenant_id": "YOUR_PROJECT_ID",
 			"type": "enterprise-db"
 		  }
 		}`)

--- a/neo4j/aura/internal/subcommands/customermanagedkey/list.go
+++ b/neo4j/aura/internal/subcommands/customermanagedkey/list.go
@@ -10,20 +10,20 @@ import (
 )
 
 func NewListCmd(cfg *clicfg.Config) *cobra.Command {
-	var tenantId string
+	var projectId string
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Returns a list of customer managed keys",
 		Long: `This subcommand returns a list containing a summary of each of your customer managed keys. To find out more about a specific key, retrieve the details using the get subcommand.
 
-You can filter keys in a particular tenant using --tenant-id. If the tenant flag is not specified, this endpoint lists all keys a user has access to across all tenants.`,
+You can filter keys in a particular project using --project-id. If the project flag is not specified, this endpoint lists all keys a user has access to across all projects.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := "/customer-managed-keys"
 			queryParams := make(map[string]string)
-			if tenantId != "" {
-				queryParams["tenantId"] = tenantId
+			if projectId != "" {
+				queryParams["tenantId"] = projectId
 			}
 			cmd.SilenceUsage = true
 			resBody, statusCode, err := api.MakeRequest(cfg, path, &api.RequestConfig{
@@ -43,7 +43,7 @@ You can filter keys in a particular tenant using --tenant-id. If the tenant flag
 		},
 	}
 
-	cmd.Flags().StringVar(&tenantId, "tenant-id", "", "An optional Tenant ID to filter customer managed keys in a tenant")
+	cmd.Flags().StringVar(&projectId, "project-id", "", "An optional Project ID to filter customer managed keys in a project")
 
 	return cmd
 }

--- a/neo4j/aura/internal/subcommands/customermanagedkey/list_test.go
+++ b/neo4j/aura/internal/subcommands/customermanagedkey/list_test.go
@@ -18,12 +18,12 @@ func TestListCustomerManagedKeys(t *testing.T) {
 			{
 				"id": "f15cc45b-1c29-44e8-911f-3ba719f70ed7",
 				"name": "Production Key",
-				"tenant_id": "YOUR_TENANT_ID"
+				"tenant_id": "YOUR_PROJECT_ID"
 			},
 			{
 				"id": "0d971cc4-f703-40fd-8c5c-f5ec134f6c84",
 				"name": "Dev Key",
-				"tenant_id": "YOUR_TENANT_ID"
+				"tenant_id": "YOUR_PROJECT_ID"
 			}
 		]
 		}`)
@@ -38,12 +38,12 @@ func TestListCustomerManagedKeys(t *testing.T) {
 				{
 					"id": "f15cc45b-1c29-44e8-911f-3ba719f70ed7",
 					"name": "Production Key",
-					"tenant_id": "YOUR_TENANT_ID"
+					"tenant_id": "YOUR_PROJECT_ID"
 				},
 				{
 					"id": "0d971cc4-f703-40fd-8c5c-f5ec134f6c84",
 					"name": "Dev Key",
-					"tenant_id": "YOUR_TENANT_ID"
+					"tenant_id": "YOUR_PROJECT_ID"
 				}
 			]
 		}
@@ -51,7 +51,7 @@ func TestListCustomerManagedKeys(t *testing.T) {
 	}
 }
 
-func TestListCustomerManagedKeysWithTenantId(t *testing.T) {
+func TestListCustomerManagedKeysWithProjectId(t *testing.T) {
 	for _, command := range []string{"customer-managed-key", "cmk"} {
 		helper := testutils.NewAuraTestHelper(t)
 		defer helper.Close()
@@ -61,17 +61,17 @@ func TestListCustomerManagedKeysWithTenantId(t *testing.T) {
 			{
 				"id": "f15cc45b-1c29-44e8-911f-3ba719f70ed7",
 				"name": "Production Key",
-				"tenant_id": "YOUR_TENANT_ID"
+				"tenant_id": "YOUR_PROJECT_ID"
 			},
 			{
 				"id": "0d971cc4-f703-40fd-8c5c-f5ec134f6c84",
 				"name": "Dev Key",
-				"tenant_id": "YOUR_TENANT_ID"
+				"tenant_id": "YOUR_PROJECT_ID"
 			}
 		]
 		}`)
 
-		helper.ExecuteCommand(fmt.Sprintf("%s list --tenant-id 1234", command))
+		helper.ExecuteCommand(fmt.Sprintf("%s list --project-id 1234", command))
 
 		mockHandler.AssertCalledTimes(1)
 		mockHandler.AssertCalledWithMethod(http.MethodGet)
@@ -82,12 +82,12 @@ func TestListCustomerManagedKeysWithTenantId(t *testing.T) {
 				{
 					"id": "f15cc45b-1c29-44e8-911f-3ba719f70ed7",
 					"name": "Production Key",
-					"tenant_id": "YOUR_TENANT_ID"
+					"tenant_id": "YOUR_PROJECT_ID"
 				},
 				{
 					"id": "0d971cc4-f703-40fd-8c5c-f5ec134f6c84",
 					"name": "Dev Key",
-					"tenant_id": "YOUR_TENANT_ID"
+					"tenant_id": "YOUR_PROJECT_ID"
 				}
 			]
 		}

--- a/neo4j/aura/internal/subcommands/instance/create.go
+++ b/neo4j/aura/internal/subcommands/instance/create.go
@@ -17,7 +17,7 @@ func NewCreateCmd(cfg *clicfg.Config) *cobra.Command {
 		memory               string
 		name                 string
 		_type                string
-		tenantId             string
+		projectId            string
 		cloudProvider        string
 		customerManagedKeyId string
 		await                bool
@@ -29,7 +29,7 @@ func NewCreateCmd(cfg *clicfg.Config) *cobra.Command {
 		memoryFlag               = "memory"
 		nameFlag                 = "name"
 		typeFlag                 = "type"
-		tenantIdFlag             = "tenant-id"
+		projectIdFlag            = "project-id"
 		cloudProviderFlag        = "cloud-provider"
 		customerManagedKeyIdFlag = "customer-managed-key-id"
 		awaitFlag                = "await"
@@ -40,11 +40,11 @@ func NewCreateCmd(cfg *clicfg.Config) *cobra.Command {
 		Short: "Creates a new instance",
 		Long: `This subcommand starts the creation process of an Aura instance.
 
-Creating an instance is an asynchronous operation that can be awaited with --await. Supported instance configurations for your tenant can be obtained by calling the tenant get subcommand.
+Creating an instance is an asynchronous operation that can be awaited with --await. Supported instance configurations for your project can be obtained by calling the project get subcommand.
 
 You can poll the current status of this operation by periodically getting the instance details for the instance ID using the get subcommand. Once the status transitions from "creating" to "running" you may begin to use your instance.
 
-This subcommand returns your instance ID, initial credentials, connection URL along with your tenant id, cloud provider, region, instance type, and the instance name for you to use once the instance is running. It is important to store these initial credentials until you have the chance to login to your running instance and change them.
+This subcommand returns your instance ID, initial credentials, connection URL along with your project id, cloud provider, region, instance type, and the instance name for you to use once the instance is running. It is important to store these initial credentials until you have the chance to login to your running instance and change them.
 
 You must also provide a --cloud-provider flag with the subcommand, which specifies which cloud provider the instances will be hosted in. The acceptable values for this field are gcp, aws, or azure.
 
@@ -56,8 +56,8 @@ For Enterprise instances you can specify a --customer-managed-key-id flag to use
 				cmd.MarkFlagRequired(regionFlag)
 			}
 
-			if cfg.Aura.DefaultTenant() == "" {
-				cmd.MarkFlagRequired(tenantIdFlag)
+			if cfg.Aura.DefaultProject() == "" {
+				cmd.MarkFlagRequired(projectIdFlag)
 			}
 
 			return nil
@@ -71,10 +71,10 @@ For Enterprise instances you can specify a --customer-managed-key-id flag to use
 				"cloud_provider": cloudProvider,
 			}
 
-			if tenantId == "" {
-				body["tenant_id"] = cfg.Aura.DefaultTenant()
+			if projectId == "" {
+				body["tenant_id"] = cfg.Aura.DefaultProject()
 			} else {
-				body["tenant_id"] = tenantId
+				body["tenant_id"] = projectId
 			}
 
 			if _type == "free-db" {
@@ -136,7 +136,7 @@ For Enterprise instances you can specify a --customer-managed-key-id flag to use
 	cmd.Flags().StringVar(&_type, typeFlag, "", "The type of the instance.")
 	cmd.MarkFlagRequired(typeFlag)
 
-	cmd.Flags().StringVar(&tenantId, tenantIdFlag, "", "")
+	cmd.Flags().StringVar(&projectId, projectIdFlag, "", "")
 
 	cmd.Flags().StringVar(&cloudProvider, cloudProviderFlag, "", "The cloud provider hosting the instance.")
 	cmd.MarkFlagRequired(cloudProviderFlag)

--- a/neo4j/aura/internal/subcommands/instance/create_test.go
+++ b/neo4j/aura/internal/subcommands/instance/create_test.go
@@ -18,7 +18,7 @@ func TestCreateFreeInstance(t *testing.T) {
 				"connection_url": "YOUR_CONNECTION_URL",
 				"username": "neo4j",
 				"password": "letMeIn123!",
-				"tenant_id": "YOUR_TENANT_ID",
+				"tenant_id": "YOUR_PROJECT_ID",
 				"cloud_provider": "gcp",
 				"region": "europe-west1",
 				"type": "free-db",
@@ -26,11 +26,11 @@ func TestCreateFreeInstance(t *testing.T) {
 			}
 		}`)
 
-	helper.ExecuteCommand("instance create --name Instance01 --type free-db --tenant-id YOUR_TENANT_ID --cloud-provider gcp")
+	helper.ExecuteCommand("instance create --name Instance01 --type free-db --project-id YOUR_PROJECT_ID --cloud-provider gcp")
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodPost)
-	mockHandler.AssertCalledWithBody(`{"cloud_provider":"gcp","memory":"1GB","name":"Instance01","region":"europe-west1","tenant_id":"YOUR_TENANT_ID","type":"free-db","version":"5"}`)
+	mockHandler.AssertCalledWithBody(`{"cloud_provider":"gcp","memory":"1GB","name":"Instance01","region":"europe-west1","tenant_id":"YOUR_PROJECT_ID","type":"free-db","version":"5"}`)
 
 	helper.AssertOutJson(`{
 	  "data": {
@@ -40,7 +40,7 @@ func TestCreateFreeInstance(t *testing.T) {
 		"name": "Instance01",
 		"password": "letMeIn123!",
 		"region": "europe-west1",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "free-db",
 		"username": "neo4j"
 	  }
@@ -57,7 +57,7 @@ func TestCreateProfessionalInstance(t *testing.T) {
 				"connection_url": "YOUR_CONNECTION_URL",
 				"username": "neo4j",
 				"password": "letMeIn123!",
-				"tenant_id": "YOUR_TENANT_ID",
+				"tenant_id": "YOUR_PROJECT_ID",
 				"cloud_provider": "gcp",
 				"region": "europe-west1",
 				"type": "professional-db",
@@ -65,11 +65,11 @@ func TestCreateProfessionalInstance(t *testing.T) {
 			}
 		}`)
 
-	helper.ExecuteCommand("instance create --region europe-west1 --name Instance01 --type professional-db --tenant-id YOUR_TENANT_ID --cloud-provider gcp --memory 4GB")
+	helper.ExecuteCommand("instance create --region europe-west1 --name Instance01 --type professional-db --project-id YOUR_PROJECT_ID --cloud-provider gcp --memory 4GB")
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodPost)
-	mockHandler.AssertCalledWithBody(`{"cloud_provider":"gcp","memory":"4GB","name":"Instance01","region":"europe-west1","tenant_id":"YOUR_TENANT_ID","type":"professional-db","version":"5"}`)
+	mockHandler.AssertCalledWithBody(`{"cloud_provider":"gcp","memory":"4GB","name":"Instance01","region":"europe-west1","tenant_id":"YOUR_PROJECT_ID","type":"professional-db","version":"5"}`)
 
 	helper.AssertOutJson(`{
 	  "data": {
@@ -79,7 +79,7 @@ func TestCreateProfessionalInstance(t *testing.T) {
 		"name": "Instance01",
 		"password": "letMeIn123!",
 		"region": "europe-west1",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "professional-db",
 		"username": "neo4j"
 	  }
@@ -92,7 +92,7 @@ func TestCreateProfessionalInstanceNoMemory(t *testing.T) {
 
 	mockHandler := helper.NewRequestHandlerMock("/v1/instances", http.StatusOK, "")
 
-	helper.ExecuteCommand("instance create --region europe-west1 --name Instance01 --type professional-db --tenant-id YOUR_TENANT_ID --cloud-provider gcp")
+	helper.ExecuteCommand("instance create --region europe-west1 --name Instance01 --type professional-db --project-id YOUR_PROJECT_ID --cloud-provider gcp")
 
 	mockHandler.AssertCalledTimes(0)
 
@@ -108,8 +108,8 @@ Flags:
   -h, --help                             help for create
       --memory string                    The size of the instance memory in GB.
       --name string                      The name of the instance (any UTF-8 characters with no trailing or leading whitespace).
+      --project-id string                
       --region string                    The region where the instance is hosted.
-      --tenant-id string                 
       --type string                      The type of the instance.
       --version string                   The Neo4j version of the instance. (default "5")
 
@@ -121,7 +121,7 @@ Global Flags:
 `)
 }
 
-func TestCreateProfessionalInstanceNoTenant(t *testing.T) {
+func TestCreateProfessionalInstanceNoProject(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()
 
@@ -131,7 +131,7 @@ func TestCreateProfessionalInstanceNoTenant(t *testing.T) {
 
 	mockHandler.AssertCalledTimes(0)
 
-	helper.AssertErr(`Error: required flag(s) "tenant-id" not set
+	helper.AssertErr(`Error: required flag(s) "project-id" not set
 `)
 	helper.AssertOut(`Usage:
   aura instance create [flags]
@@ -143,8 +143,8 @@ Flags:
   -h, --help                             help for create
       --memory string                    The size of the instance memory in GB.
       --name string                      The name of the instance (any UTF-8 characters with no trailing or leading whitespace).
+      --project-id string                
       --region string                    The region where the instance is hosted.
-      --tenant-id string                 
       --type string                      The type of the instance.
       --version string                   The Neo4j version of the instance. (default "5")
 
@@ -196,7 +196,7 @@ func TestCreateInstanceError(t *testing.T) {
 
 			mockHandler := helper.NewRequestHandlerMock("/v1/instances", testCase.statusCode, testCase.returnBody)
 
-			helper.ExecuteCommand("instance create --region europe-west1 --name Instance01 --type professional-db --tenant-id YOUR_TENANT_ID --cloud-provider gcp --memory 4GB")
+			helper.ExecuteCommand("instance create --region europe-west1 --name Instance01 --type professional-db --project-id YOUR_PROJECT_ID --cloud-provider gcp --memory 4GB")
 
 			mockHandler.AssertCalledTimes(1)
 			mockHandler.AssertCalledWithMethod(http.MethodPost)
@@ -217,7 +217,7 @@ func TestInstanceWithCmkId(t *testing.T) {
 				"connection_url": "YOUR_CONNECTION_URL",
 				"username": "neo4j",
 				"password": "letMeIn123!",
-				"tenant_id": "YOUR_TENANT_ID",
+				"tenant_id": "YOUR_PROJECT_ID",
 				"cloud_provider": "gcp",
 				"region": "europe-west1",
 				"type": "enterprise-db",
@@ -225,11 +225,11 @@ func TestInstanceWithCmkId(t *testing.T) {
 			}
 		}`)
 
-	helper.ExecuteCommand("instance create --region europe-west1 --name Instance01 --type enterprise-db --tenant-id YOUR_TENANT_ID --cloud-provider gcp --memory 16GB --customer-managed-key-id UUID_OF_YOUR_KEY")
+	helper.ExecuteCommand("instance create --region europe-west1 --name Instance01 --type enterprise-db --project-id YOUR_PROJECT_ID --cloud-provider gcp --memory 16GB --customer-managed-key-id UUID_OF_YOUR_KEY")
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodPost)
-	mockHandler.AssertCalledWithBody(`{"cloud_provider":"gcp","memory":"16GB","name":"Instance01","region":"europe-west1","tenant_id":"YOUR_TENANT_ID","type":"enterprise-db","version":"5","customer_managed_key_id":"UUID_OF_YOUR_KEY"}`)
+	mockHandler.AssertCalledWithBody(`{"cloud_provider":"gcp","memory":"16GB","name":"Instance01","region":"europe-west1","tenant_id":"YOUR_PROJECT_ID","type":"enterprise-db","version":"5","customer_managed_key_id":"UUID_OF_YOUR_KEY"}`)
 
 	helper.AssertOutJson(`{
 	  "data": {
@@ -239,18 +239,18 @@ func TestInstanceWithCmkId(t *testing.T) {
 		"name": "Instance01",
 		"password": "letMeIn123!",
 		"region": "europe-west1",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "enterprise-db",
 		"username": "neo4j"
 	  }
 	} `)
 }
 
-func TestCreateFreeInstanceWithConfigTenantId(t *testing.T) {
+func TestCreateFreeInstanceWithConfigProjectId(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()
 
-	helper.SetConfigValue("aura.default-tenant", "YOUR_TENANT_ID")
+	helper.SetConfigValue("aura.default-project", "YOUR_PROJECT_ID")
 
 	mockHandler := helper.NewRequestHandlerMock("/v1/instances", http.StatusAccepted, `{
 			"data": {
@@ -258,7 +258,7 @@ func TestCreateFreeInstanceWithConfigTenantId(t *testing.T) {
 				"connection_url": "YOUR_CONNECTION_URL",
 				"username": "neo4j",
 				"password": "letMeIn123!",
-				"tenant_id": "YOUR_TENANT_ID",
+				"tenant_id": "YOUR_PROJECT_ID",
 				"cloud_provider": "gcp",
 				"region": "europe-west1",
 				"type": "free-db",
@@ -270,7 +270,7 @@ func TestCreateFreeInstanceWithConfigTenantId(t *testing.T) {
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodPost)
-	mockHandler.AssertCalledWithBody(`{"cloud_provider":"gcp","memory":"1GB","name":"Instance01","region":"europe-west1","tenant_id":"YOUR_TENANT_ID","type":"free-db","version":"5"}`)
+	mockHandler.AssertCalledWithBody(`{"cloud_provider":"gcp","memory":"1GB","name":"Instance01","region":"europe-west1","tenant_id":"YOUR_PROJECT_ID","type":"free-db","version":"5"}`)
 
 	helper.AssertOutJson(`{
 	  "data": {
@@ -280,7 +280,7 @@ func TestCreateFreeInstanceWithConfigTenantId(t *testing.T) {
 		"name": "Instance01",
 		"password": "letMeIn123!",
 		"region": "europe-west1",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "free-db",
 		"username": "neo4j"
 	  }
@@ -297,7 +297,7 @@ func TestCreateFreeInstanceWithAwait(t *testing.T) {
 				"connection_url": "YOUR_CONNECTION_URL",
 				"username": "neo4j",
 				"password": "letMeIn123!",
-				"tenant_id": "YOUR_TENANT_ID",
+				"tenant_id": "YOUR_PROJECT_ID",
 				"cloud_provider": "gcp",
 				"region": "europe-west1",
 				"type": "free-db",
@@ -317,11 +317,11 @@ func TestCreateFreeInstanceWithAwait(t *testing.T) {
 			}
 		}`)
 
-	helper.ExecuteCommand("instance create --region europe-west1 --name Instance01 --type free-db --tenant-id YOUR_TENANT_ID --cloud-provider gcp --await")
+	helper.ExecuteCommand("instance create --region europe-west1 --name Instance01 --type free-db --project-id YOUR_PROJECT_ID --cloud-provider gcp --await")
 
 	createMock.AssertCalledTimes(1)
 	createMock.AssertCalledWithMethod(http.MethodPost)
-	createMock.AssertCalledWithBody(`{"cloud_provider":"gcp","memory":"1GB","name":"Instance01","region":"europe-west1","tenant_id":"YOUR_TENANT_ID","type":"free-db","version":"5"}`)
+	createMock.AssertCalledWithBody(`{"cloud_provider":"gcp","memory":"1GB","name":"Instance01","region":"europe-west1","tenant_id":"YOUR_PROJECT_ID","type":"free-db","version":"5"}`)
 
 	getMock.AssertCalledTimes(2)
 	getMock.AssertCalledWithMethod(http.MethodGet)
@@ -335,7 +335,7 @@ func TestCreateFreeInstanceWithAwait(t *testing.T) {
 		"name": "Instance01",
 		"password": "letMeIn123!",
 		"region": "europe-west1",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "free-db",
 		"username": "neo4j"
 	}

--- a/neo4j/aura/internal/subcommands/instance/delete_test.go
+++ b/neo4j/aura/internal/subcommands/instance/delete_test.go
@@ -20,7 +20,7 @@ func TestDeleteInstance(t *testing.T) {
 		  "name": "Production",
 		  "status": "deleting",
 		  "connection_url": "YOUR_CONNECTION_URL",
-		  "tenant_id": "YOUR_TENANT_ID",
+		  "tenant_id": "YOUR_PROJECT_ID",
 		  "cloud_provider": "gcp",
 		  "memory": "8GB",
 		  "region": "europe-west1",
@@ -42,7 +42,7 @@ func TestDeleteInstance(t *testing.T) {
 		"name": "Production",
 		"region": "europe-west1",
 		"status": "deleting",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "enterprise-db"
 	  }
 	}`)

--- a/neo4j/aura/internal/subcommands/instance/get_test.go
+++ b/neo4j/aura/internal/subcommands/instance/get_test.go
@@ -22,7 +22,7 @@ func TestGetInstance(t *testing.T) {
 				"id": "2f49c2b3",
 				"name": "Production",
 				"status": "running",
-				"tenant_id": "YOUR_TENANT_ID",
+				"tenant_id": "YOUR_PROJECT_ID",
 				"cloud_provider": "gcp",
 				"connection_url": "YOUR_CONNECTION_URL",
 				"metrics_integration_url": "YOUR_METRICS_INTEGRATION_ENDPOINT",
@@ -49,7 +49,7 @@ func TestGetInstance(t *testing.T) {
 		"region": "europe-west1",
 		"status": "running",
 		"storage": "16GB",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "enterprise-db"
 	  }
 	}`)
@@ -66,7 +66,7 @@ func TestGetEnterpriseInstanceWithTableOutput(t *testing.T) {
 				"id": "2f49c2b3",
 				"name": "Production",
 				"status": "running",
-				"tenant_id": "YOUR_TENANT_ID",
+				"tenant_id": "YOUR_PROJECT_ID",
 				"cloud_provider": "gcp",
 				"connection_url": "YOUR_CONNECTION_URL",
 				"metrics_integration_url": "YOUR_METRICS_INTEGRATION_ENDPOINT",
@@ -86,11 +86,11 @@ func TestGetEnterpriseInstanceWithTableOutput(t *testing.T) {
 	mockHandler.AssertCalledWithMethod(http.MethodGet)
 
 	helper.AssertOut(`
-┌──────────┬────────────┬────────────────┬─────────┬─────────────────────┬────────────────┬──────────────┬───────────────┬────────┬─────────┬─────────────────────────┬───────────────────────────────────┐
-│ ID       │ NAME       │ TENANT_ID      │ STATUS  │ CONNECTION_URL      │ CLOUD_PROVIDER │ REGION       │ TYPE          │ MEMORY │ STORAGE │ CUSTOMER_MANAGED_KEY_ID │ METRICS_INTEGRATION_URL           │
-├──────────┼────────────┼────────────────┼─────────┼─────────────────────┼────────────────┼──────────────┼───────────────┼────────┼─────────┼─────────────────────────┼───────────────────────────────────┤
-│ 2f49c2b3 │ Production │ YOUR_TENANT_ID │ running │ YOUR_CONNECTION_URL │ gcp            │ europe-west1 │ enterprise-db │ 8GB    │ 16GB    │                         │ YOUR_METRICS_INTEGRATION_ENDPOINT │
-└──────────┴────────────┴────────────────┴─────────┴─────────────────────┴────────────────┴──────────────┴───────────────┴────────┴─────────┴─────────────────────────┴───────────────────────────────────┘
+┌──────────┬────────────┬─────────────────┬─────────┬─────────────────────┬────────────────┬──────────────┬───────────────┬────────┬─────────┬─────────────────────────┬───────────────────────────────────┐
+│ ID       │ NAME       │ TENANT_ID       │ STATUS  │ CONNECTION_URL      │ CLOUD_PROVIDER │ REGION       │ TYPE          │ MEMORY │ STORAGE │ CUSTOMER_MANAGED_KEY_ID │ METRICS_INTEGRATION_URL           │
+├──────────┼────────────┼─────────────────┼─────────┼─────────────────────┼────────────────┼──────────────┼───────────────┼────────┼─────────┼─────────────────────────┼───────────────────────────────────┤
+│ 2f49c2b3 │ Production │ YOUR_PROJECT_ID │ running │ YOUR_CONNECTION_URL │ gcp            │ europe-west1 │ enterprise-db │ 8GB    │ 16GB    │                         │ YOUR_METRICS_INTEGRATION_ENDPOINT │
+└──────────┴────────────┴─────────────────┴─────────┴─────────────────────┴────────────────┴──────────────┴───────────────┴────────┴─────────┴─────────────────────────┴───────────────────────────────────┘
 `)
 
 }
@@ -106,7 +106,7 @@ func TestGetProfessionalInstanceWithTableOutput(t *testing.T) {
 				"id": "2f49c2b3",
 				"name": "Production",
 				"status": "running",
-				"tenant_id": "YOUR_TENANT_ID",
+				"tenant_id": "YOUR_PROJECT_ID",
 				"cloud_provider": "gcp",
 				"connection_url": "YOUR_CONNECTION_URL",
 				"region": "europe-west1",
@@ -125,11 +125,11 @@ func TestGetProfessionalInstanceWithTableOutput(t *testing.T) {
 	mockHandler.AssertCalledWithMethod(http.MethodGet)
 
 	helper.AssertOut(`
-┌──────────┬────────────┬────────────────┬─────────┬─────────────────────┬────────────────┬──────────────┬─────────────────┬────────┬─────────┬─────────────────────────┐
-│ ID       │ NAME       │ TENANT_ID      │ STATUS  │ CONNECTION_URL      │ CLOUD_PROVIDER │ REGION       │ TYPE            │ MEMORY │ STORAGE │ CUSTOMER_MANAGED_KEY_ID │
-├──────────┼────────────┼────────────────┼─────────┼─────────────────────┼────────────────┼──────────────┼─────────────────┼────────┼─────────┼─────────────────────────┤
-│ 2f49c2b3 │ Production │ YOUR_TENANT_ID │ running │ YOUR_CONNECTION_URL │ gcp            │ europe-west1 │ professional-db │ 8GB    │ 16GB    │                         │
-└──────────┴────────────┴────────────────┴─────────┴─────────────────────┴────────────────┴──────────────┴─────────────────┴────────┴─────────┴─────────────────────────┘
+┌──────────┬────────────┬─────────────────┬─────────┬─────────────────────┬────────────────┬──────────────┬─────────────────┬────────┬─────────┬─────────────────────────┐
+│ ID       │ NAME       │ TENANT_ID       │ STATUS  │ CONNECTION_URL      │ CLOUD_PROVIDER │ REGION       │ TYPE            │ MEMORY │ STORAGE │ CUSTOMER_MANAGED_KEY_ID │
+├──────────┼────────────┼─────────────────┼─────────┼─────────────────────┼────────────────┼──────────────┼─────────────────┼────────┼─────────┼─────────────────────────┤
+│ 2f49c2b3 │ Production │ YOUR_PROJECT_ID │ running │ YOUR_CONNECTION_URL │ gcp            │ europe-west1 │ professional-db │ 8GB    │ 16GB    │                         │
+└──────────┴────────────┴─────────────────┴─────────┴─────────────────────┴────────────────┴──────────────┴─────────────────┴────────┴─────────┴─────────────────────────┘
 `)
 
 }

--- a/neo4j/aura/internal/subcommands/instance/list.go
+++ b/neo4j/aura/internal/subcommands/instance/list.go
@@ -10,20 +10,20 @@ import (
 )
 
 func NewListCmd(cfg *clicfg.Config) *cobra.Command {
-	var tenantId string
+	var projectId string
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Returns a list of instances",
 		Long: `This subcommand returns a list containing a summary of each of your Aura instances. To find out more about a specific instance, retrieve the details using the get subcommand.
 
-You can filter instances in a particular tenant using --tenant-id. If the tenant flag is not specified, this subcommand lists all instances a user has access to across all tenants.`,
+You can filter instances in a particular project using --project-id. If the project flag is not specified, this subcommand lists all instances a user has access to across all projects.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := "/instances"
 
 			queryParams := make(map[string]string)
-			if tenantId != "" {
-				queryParams["tenantId"] = tenantId
+			if projectId != "" {
+				queryParams["tenantId"] = projectId
 			}
 
 			cmd.SilenceUsage = true
@@ -45,7 +45,7 @@ You can filter instances in a particular tenant using --tenant-id. If the tenant
 		},
 	}
 
-	cmd.Flags().StringVar(&tenantId, "tenant-id", "", "An optional Tenant ID to filter instances in a tenant")
+	cmd.Flags().StringVar(&projectId, "project-id", "", "An optional Project ID to filter instances in a project")
 
 	return cmd
 }

--- a/neo4j/aura/internal/subcommands/instance/list_test.go
+++ b/neo4j/aura/internal/subcommands/instance/list_test.go
@@ -16,25 +16,25 @@ func TestListInstances(t *testing.T) {
 				{
 					"id": "2f49c2b3",
 					"name": "Production",
-					"tenant_id": "YOUR_TENANT_ID",
+					"tenant_id": "YOUR_PROJECT_ID",
 					"cloud_provider": "gcp"
 				},
 				{
 					"id": "b51dc964",
 					"name": "Instance01",
-					"tenant_id": "YOUR_TENANT_ID",
+					"tenant_id": "YOUR_PROJECT_ID",
 					"cloud_provider": "aws"
 				},
 				{
 					"id": "432392ae",
 					"name": "Recommendations",
-					"tenant_id": "YOUR_TENANT_ID",
+					"tenant_id": "YOUR_PROJECT_ID",
 					"cloud_provider": "azure"
 				},
 				{
 					"id": "524b7d8d",
 					"name": "Northwind",
-					"tenant_id": "YOUR_TENANT_ID",
+					"tenant_id": "YOUR_PROJECT_ID",
 					"cloud_provider": "gcp"
 				}
 			]
@@ -51,31 +51,31 @@ func TestListInstances(t *testing.T) {
 		  "cloud_provider": "gcp",
 		  "id": "2f49c2b3",
 		  "name": "Production",
-		  "tenant_id": "YOUR_TENANT_ID"
+		  "tenant_id": "YOUR_PROJECT_ID"
 		},
 		{
 		  "cloud_provider": "aws",
 		  "id": "b51dc964",
 		  "name": "Instance01",
-		  "tenant_id": "YOUR_TENANT_ID"
+		  "tenant_id": "YOUR_PROJECT_ID"
 		},
 		{
 		  "cloud_provider": "azure",
 		  "id": "432392ae",
 		  "name": "Recommendations",
-		  "tenant_id": "YOUR_TENANT_ID"
+		  "tenant_id": "YOUR_PROJECT_ID"
 		},
 		{
 		  "cloud_provider": "gcp",
 		  "id": "524b7d8d",
 		  "name": "Northwind",
-		  "tenant_id": "YOUR_TENANT_ID"
+		  "tenant_id": "YOUR_PROJECT_ID"
 		}
 	  ]
 	}`)
 }
 
-func TestListInstancesWithTenantId(t *testing.T) {
+func TestListInstancesWithProjectId(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()
 
@@ -84,35 +84,35 @@ func TestListInstancesWithTenantId(t *testing.T) {
 				{
 					"id": "2f49c2b3",
 					"name": "Production",
-					"tenant_id": "YOUR_TENANT_ID",
+					"tenant_id": "YOUR_PROJECT_ID",
 					"cloud_provider": "gcp"
 				},
 				{
 					"id": "b51dc964",
 					"name": "Instance01",
-					"tenant_id": "YOUR_TENANT_ID",
+					"tenant_id": "YOUR_PROJECT_ID",
 					"cloud_provider": "aws"
 				},
 				{
 					"id": "432392ae",
 					"name": "Recommendations",
-					"tenant_id": "YOUR_TENANT_ID",
+					"tenant_id": "YOUR_PROJECT_ID",
 					"cloud_provider": "azure"
 				},
 				{
 					"id": "524b7d8d",
 					"name": "Northwind",
-					"tenant_id": "YOUR_TENANT_ID",
+					"tenant_id": "YOUR_PROJECT_ID",
 					"cloud_provider": "gcp"
 				}
 			]
 		}`)
 
-	helper.ExecuteCommand("instance list --tenant-id my-tenant-id")
+	helper.ExecuteCommand("instance list --project-id my-project-id")
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodGet)
-	mockHandler.AssertCalledWithQueryParam("tenantId", "my-tenant-id")
+	mockHandler.AssertCalledWithQueryParam("tenantId", "my-project-id")
 
 	helper.AssertOutJson(`{
 	  "data": [
@@ -120,25 +120,25 @@ func TestListInstancesWithTenantId(t *testing.T) {
 		  "cloud_provider": "gcp",
 		  "id": "2f49c2b3",
 		  "name": "Production",
-		  "tenant_id": "YOUR_TENANT_ID"
+		  "tenant_id": "YOUR_PROJECT_ID"
 		},
 		{
 		  "cloud_provider": "aws",
 		  "id": "b51dc964",
 		  "name": "Instance01",
-		  "tenant_id": "YOUR_TENANT_ID"
+		  "tenant_id": "YOUR_PROJECT_ID"
 		},
 		{
 		  "cloud_provider": "azure",
 		  "id": "432392ae",
 		  "name": "Recommendations",
-		  "tenant_id": "YOUR_TENANT_ID"
+		  "tenant_id": "YOUR_PROJECT_ID"
 		},
 		{
 		  "cloud_provider": "gcp",
 		  "id": "524b7d8d",
 		  "name": "Northwind",
-		  "tenant_id": "YOUR_TENANT_ID"
+		  "tenant_id": "YOUR_PROJECT_ID"
 		}
 	  ]
 	}`)

--- a/neo4j/aura/internal/subcommands/instance/overwrite_test.go
+++ b/neo4j/aura/internal/subcommands/instance/overwrite_test.go
@@ -21,7 +21,7 @@ func TestOverwriteFromInstance(t *testing.T) {
 		  "name": "Production",
 		  "status": "overwriting",
 		  "connection_url": "YOUR_CONNECTION_URL",
-		  "tenant_id": "YOUR_TENANT_ID",
+		  "tenant_id": "YOUR_PROJECT_ID",
 		  "cloud_provider": "gcp",
 		  "memory": "8GB",
 		  "region": "europe-west1",
@@ -44,7 +44,7 @@ func TestOverwriteFromInstance(t *testing.T) {
 		"name": "Production",
 		"region": "europe-west1",
 		"status": "overwriting",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "enterprise-db"
 	  }
 	}`)
@@ -64,7 +64,7 @@ func TestOverwriteFromSnapshot(t *testing.T) {
 		  "name": "Production",
 		  "status": "overwriting",
 		  "connection_url": "YOUR_CONNECTION_URL",
-		  "tenant_id": "YOUR_TENANT_ID",
+		  "tenant_id": "YOUR_PROJECT_ID",
 		  "cloud_provider": "gcp",
 		  "memory": "8GB",
 		  "region": "europe-west1",
@@ -88,7 +88,7 @@ func TestOverwriteFromSnapshot(t *testing.T) {
 		"name": "Production",
 		"region": "europe-west1",
 		"status": "overwriting",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "enterprise-db"
 	  }
 	}`)
@@ -107,7 +107,7 @@ func TestOverwriteWithAwait(t *testing.T) {
 		  "name": "Production",
 		  "status": "overwriting",
 		  "connection_url": "YOUR_CONNECTION_URL",
-		  "tenant_id": "YOUR_TENANT_ID",
+		  "tenant_id": "YOUR_PROJECT_ID",
 		  "cloud_provider": "gcp",
 		  "memory": "8GB",
 		  "region": "europe-west1",
@@ -147,7 +147,7 @@ func TestOverwriteWithAwait(t *testing.T) {
 		"name": "Production",
 		"region": "europe-west1",
 		"status": "overwriting",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "enterprise-db"
 	}
 }

--- a/neo4j/aura/internal/subcommands/instance/pause_test.go
+++ b/neo4j/aura/internal/subcommands/instance/pause_test.go
@@ -20,7 +20,7 @@ func TestPauseInstance(t *testing.T) {
 		  "name": "Production",
 		  "status": "pausing",
 		  "connection_url": "YOUR_CONNECTION_URL",
-		  "tenant_id": "YOUR_TENANT_ID",
+		  "tenant_id": "YOUR_PROJECT_ID",
 		  "cloud_provider": "gcp",
 		  "memory": "8GB",
 		  "region": "europe-west1",
@@ -42,7 +42,7 @@ func TestPauseInstance(t *testing.T) {
 		"name": "Production",
 		"region": "europe-west1",
 		"status": "pausing",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "enterprise-db"
 	  }
 	}`)

--- a/neo4j/aura/internal/subcommands/instance/resume_test.go
+++ b/neo4j/aura/internal/subcommands/instance/resume_test.go
@@ -20,7 +20,7 @@ func TestResumeInstance(t *testing.T) {
 		  "name": "Production",
 		  "status": "resuming",
 		  "connection_url": "YOUR_CONNECTION_URL",
-		  "tenant_id": "YOUR_TENANT_ID",
+		  "tenant_id": "YOUR_PROJECT_ID",
 		  "cloud_provider": "gcp",
 		  "memory": "8GB",
 		  "region": "europe-west1",
@@ -42,7 +42,7 @@ func TestResumeInstance(t *testing.T) {
 		"name": "Production",
 		"region": "europe-west1",
 		"status": "resuming",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "enterprise-db"
 	  }
 	}`)

--- a/neo4j/aura/internal/subcommands/instance/update_test.go
+++ b/neo4j/aura/internal/subcommands/instance/update_test.go
@@ -20,7 +20,7 @@ func TestUpdateMemory(t *testing.T) {
 			"name": "Production",
 			"status": "updating",
 			"connection_url": "YOUR_CONNECTION_URL",
-			"tenant_id": "YOUR_TENANT_ID",
+			"tenant_id": "YOUR_PROJECT_ID",
 			"cloud_provider": "gcp",
 			"memory": "8GB",
 			"region": "europe-west1",
@@ -43,7 +43,7 @@ func TestUpdateMemory(t *testing.T) {
 		"name": "Production",
 		"region": "europe-west1",
 		"status": "updating",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "enterprise-db"
 	  }
 	}`)
@@ -61,7 +61,7 @@ func TestUpdateName(t *testing.T) {
 			"name": "New Name",
 			"status": "updating",
 			"connection_url": "YOUR_CONNECTION_URL",
-			"tenant_id": "YOUR_TENANT_ID",
+			"tenant_id": "YOUR_PROJECT_ID",
 			"cloud_provider": "gcp",
 			"memory": "4GB",
 			"region": "europe-west1",
@@ -84,7 +84,7 @@ func TestUpdateName(t *testing.T) {
 		"name": "New Name",
 		"region": "europe-west1",
 		"status": "updating",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "enterprise-db"
 	  }
 	}`)
@@ -102,7 +102,7 @@ func TestUpdateMemoryAndName(t *testing.T) {
 			"name": "New Name",
 			"status": "updating",
 			"connection_url": "YOUR_CONNECTION_URL",
-			"tenant_id": "YOUR_TENANT_ID",
+			"tenant_id": "YOUR_PROJECT_ID",
 			"cloud_provider": "gcp",
 			"memory": "8GB",
 			"region": "europe-west1",
@@ -125,7 +125,7 @@ func TestUpdateMemoryAndName(t *testing.T) {
 		"name": "New Name",
 		"region": "europe-west1",
 		"status": "updating",
-		"tenant_id": "YOUR_TENANT_ID",
+		"tenant_id": "YOUR_PROJECT_ID",
 		"type": "enterprise-db"
 	  }
 	}`)

--- a/neo4j/aura/internal/subcommands/project/get.go
+++ b/neo4j/aura/internal/subcommands/project/get.go
@@ -1,4 +1,4 @@
-package tenant
+package project
 
 import (
 	"fmt"
@@ -14,12 +14,12 @@ import (
 func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <id>",
-		Short: "Returns tenant details",
-		Long:  "This subcommand returns details about a specific Aura Tenant.",
+		Short: "Returns project details",
+		Long:  "This subcommand returns details about a specific Aura Project.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tenantId := args[0]
-			path := fmt.Sprintf("/tenants/%s", tenantId)
+			projectId := args[0]
+			path := fmt.Sprintf("/tenants/%s", projectId)
 
 			cmd.SilenceUsage = true
 			resBody, statusCode, err := api.MakeRequest(cfg, path, &api.RequestConfig{
@@ -34,7 +34,7 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				fields, values, err := postProcessResponseValues(cfg, tenantId, responseData)
+				fields, values, err := postProcessResponseValues(cfg, projectId, responseData)
 				if err != nil {
 					return err
 				}
@@ -49,29 +49,29 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 	}
 }
 
-func postProcessResponseValues(cfg *clicfg.Config, tenantId string, responseData api.ResponseData) ([]string, api.ResponseData, error) {
-	metricsIntegrationEndpointUrl, err := getMetricsIntegrationEndpointUrl(cfg, tenantId)
+func postProcessResponseValues(cfg *clicfg.Config, projectId string, responseData api.ResponseData) ([]string, api.ResponseData, error) {
+	metricsIntegrationEndpointUrl, err := getMetricsIntegrationEndpointUrl(cfg, projectId)
 	if err != nil {
 		return nil, nil, err
 	}
 	fields := []string{"id", "name"}
 	if len(metricsIntegrationEndpointUrl) > 0 {
-		tenant, err := responseData.GetSingleOrError()
+		project, err := responseData.GetSingleOrError()
 		if err != nil {
 			return nil, nil, err
 		}
-		tenant["metrics_integration_url"] = metricsIntegrationEndpointUrl
-		return append(fields, "metrics_integration_url"), api.NewSingleValueResponseData(tenant), nil
+		project["metrics_integration_url"] = metricsIntegrationEndpointUrl
+		return append(fields, "metrics_integration_url"), api.NewSingleValueResponseData(project), nil
 	} else {
 		return fields, responseData, nil
 	}
 }
 
-func getMetricsIntegrationEndpointUrl(cfg *clicfg.Config, tenantId string) (string, error) {
-	resBody, statusCode, err := api.MakeRequest(cfg, fmt.Sprintf("/tenants/%s/metrics-integration", tenantId), &api.RequestConfig{
+func getMetricsIntegrationEndpointUrl(cfg *clicfg.Config, projectId string) (string, error) {
+	resBody, statusCode, err := api.MakeRequest(cfg, fmt.Sprintf("/tenants/%s/metrics-integration", projectId), &api.RequestConfig{
 		Method: http.MethodGet,
 	})
-	// Aura API (in fact Console API returns HTTP 400 when CMI endpoint is not available for the tenant)
+	// Aura API (in fact Console API returns HTTP 400 when CMI endpoint is not available for the project)
 	if err != nil && statusCode != http.StatusBadRequest {
 		return "", err
 	}

--- a/neo4j/aura/internal/subcommands/project/get_test.go
+++ b/neo4j/aura/internal/subcommands/project/get_test.go
@@ -1,4 +1,4 @@
-package tenant_test
+package project_test
 
 import (
 	"fmt"
@@ -8,13 +8,13 @@ import (
 	"github.com/neo4j/cli/neo4j/aura/internal/test/testutils"
 )
 
-func TestGetTenantWithoutIntegrationEndpoint(t *testing.T) {
+func TestGetProjectWithoutIntegrationEndpoint(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()
 
-	tenantId := "6981ace7-efe8-4f5c-b7c5-267b5162ce91"
+	projectId := "6981ace7-efe8-4f5c-b7c5-267b5162ce91"
 
-	getMockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s", tenantId), http.StatusOK, `{
+	getMockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s", projectId), http.StatusOK, `{
 			"data": {
 				"id": "6981ace7-efe8-4f5c-b7c5-267b5162ce91",
 				"name": "Production",
@@ -22,16 +22,16 @@ func TestGetTenantWithoutIntegrationEndpoint(t *testing.T) {
 			}
 		}`)
 
-	metricsIntegrationMockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s/metrics-integration", tenantId), http.StatusBadRequest, `{
+	metricsIntegrationMockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s/metrics-integration", projectId), http.StatusBadRequest, `{
 			"errors": [
 				{
-					"message": "This tenant has no instances eligible for metrics integration",
+					"message": "This project has no instances eligible for metrics integration",
 					"reason": "tenant-incapable-of-action"
 				}
 			]
 		}`)
 
-	helper.ExecuteCommand(fmt.Sprintf("tenant get %s", tenantId))
+	helper.ExecuteCommand(fmt.Sprintf("project get %s", projectId))
 
 	getMockHandler.AssertCalledTimes(1)
 	getMockHandler.AssertCalledWithMethod(http.MethodGet)
@@ -47,13 +47,13 @@ func TestGetTenantWithoutIntegrationEndpoint(t *testing.T) {
 	}
 	`)
 }
-func TestGetTenantWithMetricsIntegrationEndpoint(t *testing.T) {
+func TestGetProjectWithMetricsIntegrationEndpoint(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()
 
-	tenantId := "6981ace7-efe8-4f5c-b7c5-267b5162ce91"
+	projectId := "6981ace7-efe8-4f5c-b7c5-267b5162ce91"
 
-	getMockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s", tenantId), http.StatusOK, `{
+	getMockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s", projectId), http.StatusOK, `{
 			"data": {
 				"id": "6981ace7-efe8-4f5c-b7c5-267b5162ce91",
 				"name": "Production",
@@ -61,13 +61,13 @@ func TestGetTenantWithMetricsIntegrationEndpoint(t *testing.T) {
 			}
 		}`)
 
-	metricsIntegrationMockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s/metrics-integration", tenantId), http.StatusOK, `{
+	metricsIntegrationMockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s/metrics-integration", projectId), http.StatusOK, `{
 			"data": {
 				"endpoint": "https://customer-metrics-api-devnommrr.neo4j-dev.io/api/v1/ca7bc96c-204c-546e-9736-f4a578d53f64/metrics"
 			}
 		}`)
 
-	helper.ExecuteCommand(fmt.Sprintf("tenant get %s", tenantId))
+	helper.ExecuteCommand(fmt.Sprintf("project get %s", projectId))
 
 	getMockHandler.AssertCalledTimes(1)
 	getMockHandler.AssertCalledWithMethod(http.MethodGet)
@@ -85,13 +85,13 @@ func TestGetTenantWithMetricsIntegrationEndpoint(t *testing.T) {
 	`)
 }
 
-func TestGetTenantNotFoundError(t *testing.T) {
+func TestGetProjectNotFoundError(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()
 
-	tenantId := "6981ace7-efe8-4f5c-b7c5-267b5162ce91"
+	projectId := "6981ace7-efe8-4f5c-b7c5-267b5162ce91"
 
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s", tenantId), http.StatusNotFound, `{
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s", projectId), http.StatusNotFound, `{
 		"errors": [
 			{
 			"message": "The tenant you specified could not be found",
@@ -100,7 +100,7 @@ func TestGetTenantNotFoundError(t *testing.T) {
 		]
 		}`)
 
-	helper.ExecuteCommand(fmt.Sprintf("tenant get %s", tenantId))
+	helper.ExecuteCommand(fmt.Sprintf("project get %s", projectId))
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodGet)

--- a/neo4j/aura/internal/subcommands/project/list.go
+++ b/neo4j/aura/internal/subcommands/project/list.go
@@ -1,4 +1,4 @@
-package tenant
+package project
 
 import (
 	"net/http"
@@ -12,8 +12,8 @@ import (
 func NewListCmd(cfg *clicfg.Config) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "Returns a list of tenants",
-		Long:  "This subcommand returns a list containing a summary of each of your Aura Tenants. To find out more about a specific Tenant, retrieve the details using the get subcommand.",
+		Short: "Returns a list of projects",
+		Long:  "This subcommand returns a list containing a summary of each of your Aura Projects. To find out more about a specific Project, retrieve the details using the get subcommand.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			resBody, statusCode, err := api.MakeRequest(cfg, "/tenants", &api.RequestConfig{

--- a/neo4j/aura/internal/subcommands/project/list_test.go
+++ b/neo4j/aura/internal/subcommands/project/list_test.go
@@ -1,4 +1,4 @@
-package tenant_test
+package project_test
 
 import (
 	"net/http"
@@ -7,7 +7,7 @@ import (
 	"github.com/neo4j/cli/neo4j/aura/internal/test/testutils"
 )
 
-func TestListTenants(t *testing.T) {
+func TestListProjects(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()
 
@@ -18,7 +18,7 @@ func TestListTenants(t *testing.T) {
 				"name": "Production"
 				},
 				{
-				"id": "YOUR_TENANT_ID",
+				"id": "YOUR_PROJECT_ID",
 				"name": "Staging"
 				},
 				{
@@ -28,7 +28,7 @@ func TestListTenants(t *testing.T) {
 			]
 		}`)
 
-	helper.ExecuteCommand("tenant list")
+	helper.ExecuteCommand("project list")
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodGet)
@@ -40,7 +40,7 @@ func TestListTenants(t *testing.T) {
 				"name": "Production"
 			},
 			{
-				"id": "YOUR_TENANT_ID",
+				"id": "YOUR_PROJECT_ID",
 				"name": "Staging"
 			},
 			{

--- a/neo4j/aura/internal/subcommands/project/project.go
+++ b/neo4j/aura/internal/subcommands/project/project.go
@@ -1,4 +1,4 @@
-package tenant
+package project
 
 import (
 	"github.com/spf13/cobra"
@@ -8,8 +8,8 @@ import (
 
 func NewCmd(cfg *clicfg.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "tenant",
-		Short: "Relates to an Aura Tenant",
+		Use:   "project",
+		Short: "Relates to an Aura Project",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := cfg.Aura.BindBaseUrl(cmd.Flags().Lookup("base-url")); err != nil {
 				return err


### PR DESCRIPTION
This PR changes `tenant` to `project` in the CLI input, to avoid breaking changes in the very near future. 

However, `tenant` is still output in responses from the API. We could consider a transformer here, or leave it as it is and wait for the API to change.