### PR TITLE
Add data api cors policy cmds

### DIFF
--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/authprovider/create.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/authprovider/create.go
@@ -39,7 +39,7 @@ func NewCreateCmd(cfg *clicfg.Config) *cobra.Command {
 		Short: "Creates a new GraphQL Data API authentication provider",
 		Long: `This command creates a new GraphQL Data API authentication provider.
 
-Creating a GraphQL Data API authentication provider is an asynchronous operation. Use the --await flag to wait for the GraphQL Data API to be ready. Once the status transitions from "creating" to "ready" you may begin to use your GraphQL Data API.
+Creating a GraphQL Data API authentication provider is an asynchronous operation. Use the --await flag to wait for the GraphQL Data API to be ready. Once the status transitions from "updating" to "ready" you may begin to use your GraphQL Data API.
 
 If you create an 'api-key' Authentication provider, an API key will be created. It is important to store the API key as it is not currently possible to get it or update it.
 
@@ -119,7 +119,7 @@ If you lose your API key, you will need to create a new Authentication provider.
 	msgUrlFlag := fmt.Sprintf("The JWKS URL that you want the bearer tokens in incoming GraphQL requests to be validated against. NOTE: only applicable for Authentication provider type '%s'", api.GraphQLDataApiAuthProviderTypeJwks)
 	cmd.Flags().StringVar(&url, urlFlag, "", msgUrlFlag)
 
-	cmd.Flags().BoolVar(&await, awaitFlag, false, "Waits until created GraphQL Data API is ready.")
+	cmd.Flags().BoolVar(&await, awaitFlag, false, "Waits until created Authentication provider is ready.")
 
 	return cmd
 }

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add.go
@@ -85,10 +85,10 @@ Adding a new allowed origin to the CORS policy of a GraphQL Data API allows brow
 		},
 	}
 
-	cmd.Flags().StringVar(&instanceId, instanceIdFlag, "", "(required) The ID of the instance to create the GraphQL Data API for")
+	cmd.Flags().StringVar(&instanceId, instanceIdFlag, "", "(required) The ID of the instance the GraphQL Data API is connected to")
 	cmd.MarkFlagRequired(instanceIdFlag)
 
-	cmd.Flags().StringVar(&dataApiId, dataApiIdFlag, "", "(required) The ID of the GraphQL Data API to create the authentication provider for")
+	cmd.Flags().StringVar(&dataApiId, dataApiIdFlag, "", "(required) The ID of the GraphQL Data API to add the CORS allowed origin for")
 	cmd.MarkFlagRequired(dataApiIdFlag)
 
 	cmd.Flags().BoolVar(&await, awaitFlag, false, "Waits until updated GraphQL Data API is ready.")

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/neo4j/cli/common/clicfg"
+	"github.com/neo4j/cli/common/clierr"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/output"
 	"github.com/spf13/cobra"
@@ -43,8 +44,8 @@ Adding a new allowed origin to the CORS policy of a GraphQL Data API allows brow
 
 			for _, origin := range existingOrigins {
 				if origin == newOrigin {
-					cmd.Println("Origin already exists in allowed origins:", newOrigin)
-					return nil
+					cmd.SilenceUsage = true
+					return clierr.NewUsageError("Origin \"%s\" already exists in allowed origins", newOrigin)
 				}
 			}
 

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add.go
@@ -37,7 +37,7 @@ Adding a new allowed origin to the CORS policy of a GraphQL Data API allows brow
 		RunE: func(cmd *cobra.Command, args []string) error {
 			newOrigin := args[0]
 
-			existingOrigins, err := getGetExistingOrigins(cfg, dataApiId, instanceId)
+			existingOrigins, err := getExistingOrigins(cfg, dataApiId, instanceId)
 			if err != nil {
 				return err
 			}

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add.go
@@ -1,0 +1,99 @@
+package allowedorigin
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/neo4j/cli/common/clicfg"
+	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
+	"github.com/neo4j/cli/neo4j-cli/aura/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func NewAddCmd(cfg *clicfg.Config) *cobra.Command {
+	const (
+		instanceIdFlag = "instance-id"
+		dataApiIdFlag  = "data-api-id"
+		awaitFlag      = "await"
+	)
+
+	var (
+		instanceId string
+		dataApiId  string
+		await      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "add <origin>",
+		Short: "Adds a new allowed origin to the CORS policy",
+		Long: `This command adds a new allowed origin to the Cross-Origin Resource Sharing (CORS) policy of a GraphQL Data API.
+
+Updating the CORS policy of a GraphQL Data API is an asynchronous operation. Use the --await flag to wait for the GraphQL Data API to be ready. Once the status transitions from "updating" to "ready" you may begin to use your GraphQL Data API.
+
+Adding a new allowed origin to the CORS policy of a GraphQL Data API allows browsers to make requests to the GraphQL Data API from a web app that is served from the specified origin.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			newOrigin := args[0]
+
+			existingOrigins, err := getGetExistingOrigins(cfg, dataApiId, instanceId)
+			if err != nil {
+				return err
+			}
+
+			for _, origin := range existingOrigins {
+				if origin == newOrigin {
+					cmd.Println("Origin already exists in allowed origins:", newOrigin)
+					return nil
+				}
+			}
+
+			newOrigins := append(existingOrigins, newOrigin)
+
+			fmt.Println("Existing allowed origins:", existingOrigins)
+			fmt.Println("Adding new origin:", newOrigin)
+			fmt.Println("New allowed origins:", newOrigins)
+
+			cmd.SilenceUsage = true
+			body := map[string]any{
+				"security": map[string]any{
+					"cors_policy": map[string]any{
+						"allowed_origins": newOrigins,
+					},
+				},
+			}
+			path := fmt.Sprintf("/instances/%s/data-apis/graphql/%s", instanceId, dataApiId)
+			resBody, statusCode, err := api.MakeRequest(cfg, path, &api.RequestConfig{
+				PostBody: body,
+				Method:   http.MethodPatch,
+			})
+			if err != nil {
+				return err
+			}
+
+			// NOTE: Update should not return OK (200), it always returns 202, checking both just in case
+			if statusCode == http.StatusAccepted || statusCode == http.StatusOK {
+				output.PrintBody(cmd, cfg, resBody, []string{"id", "name", "status", "url"})
+				if await {
+					cmd.Println("Waiting for GraphQL Data API to be ready...")
+					pollResponse, err := api.PollGraphQLDataApi(cfg, instanceId, dataApiId, api.GraphQLDataApiStatusCreating)
+					if err != nil {
+						return err
+					}
+
+					cmd.Println("GraphQL Data API Status:", pollResponse.Data.Status)
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&instanceId, instanceIdFlag, "", "(required) The ID of the instance to create the GraphQL Data API for")
+	cmd.MarkFlagRequired(instanceIdFlag)
+
+	cmd.Flags().StringVar(&dataApiId, dataApiIdFlag, "", "(required) The ID of the GraphQL Data API to create the authentication provider for")
+	cmd.MarkFlagRequired(dataApiIdFlag)
+
+	cmd.Flags().BoolVar(&await, awaitFlag, false, "Waits until updated GraphQL Data API is ready.")
+
+	return cmd
+}

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add_test.go
@@ -1,0 +1,48 @@
+package allowedorigin_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/neo4j/cli/neo4j-cli/aura/internal/test/testutils"
+)
+
+func TestAddAllowedOriginFlagsValidation(t *testing.T) {
+	helper := testutils.NewAuraTestHelper(t)
+	defer helper.Close()
+
+	helper.SetConfigValue("aura.beta-enabled", true)
+
+	instanceId := "2f49c2b3"
+	dataApiId := "e157301d"
+	allowedOrigin := "https://test.com"
+
+	tests := map[string]struct {
+		executedCommand string
+		expectedError   string
+	}{
+		"missing all flags": {
+			executedCommand: fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s", allowedOrigin),
+			expectedError:   "Error: required flag(s) \"data-api-id\", \"instance-id\" not set",
+		},
+		"missing origin": {
+			executedCommand: fmt.Sprintf("data-api graphql cors-policy allowed-origin add --data-api-id %s --instance-id %s", dataApiId, instanceId),
+			expectedError:   "Error: accepts 1 arg(s), received 0",
+		},
+		"missing data api id flag": {
+			executedCommand: fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s --instance-id %s", allowedOrigin, instanceId),
+			expectedError:   "Error: required flag(s) \"data-api-id\" not set",
+		},
+		"missing instance id flag": {
+			executedCommand: fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s --data-api-id %s", allowedOrigin, dataApiId),
+			expectedError:   "Error: required flag(s) \"instance-id\" not set",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			helper.ExecuteCommand(tt.executedCommand)
+			helper.AssertErr(tt.expectedError)
+		})
+	}
+}

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add_test.go
@@ -2,6 +2,7 @@ package allowedorigin_test
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/test/testutils"
@@ -43,6 +44,158 @@ func TestAddAllowedOriginFlagsValidation(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			helper.ExecuteCommand(tt.executedCommand)
 			helper.AssertErr(tt.expectedError)
+		})
+	}
+}
+
+func TestAddAllowedOriginWithResponse(t *testing.T) {
+	instanceId := "2f49c2b3"
+	dataApiId := "e157301d"
+	allowedOrigin := "https://test.com"
+
+	mockGetResponseNoOrigins := `{
+		"data": {
+			"id": "2f49c2b3",
+			"name": "my-data-api-1",
+			"status": "ready",
+			"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql",
+			"security": {
+				"cors_policy": {
+					"allowed_origins": []
+				}
+			}
+		}
+	}`
+
+	mockGetResponseWithOrigins := `{
+		"data": {
+			"id": "2f49c2b3",
+			"name": "my-data-api-1",
+			"status": "ready",
+			"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql",
+			"security": {
+				"cors_policy": {
+					"allowed_origins": ["https://test1.com", "https://test2.com"]
+				}
+			}
+		}
+	}`
+
+	mockGetResponseWithExistingOrigin := fmt.Sprintf(`{
+		"data": {
+			"id": "2f49c2b3",
+			"name": "my-data-api-1",
+			"status": "ready",
+			"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql",
+			"security": {
+				"cors_policy": {
+					"allowed_origins": ["https://test1.com", "%s", "https://test2.com"]
+				}
+			}
+		}
+	}`, allowedOrigin)
+
+	mockPatchResponse := `{
+		"data": {
+			"id": "2f49c2b3",
+			"name": "my-data-api-1",
+			"status": "ready",
+			"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql"
+		}
+	}`
+
+	expectedResponseJsonSingleOrigin := fmt.Sprintf(`New allowed origins: ["%s"]
+{
+	"data": {
+		"id": "2f49c2b3",
+		"name": "my-data-api-1",
+		"status": "ready",
+		"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql"
+	}
+}`, allowedOrigin)
+	expectedResponseJsonMultipleOrigins := fmt.Sprintf(`New allowed origins: ["https://test1.com", "https://test2.com", "%s"]
+{
+	"data": {
+		"id": "2f49c2b3",
+		"name": "my-data-api-1",
+		"status": "ready",
+		"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql"
+	}
+}`, allowedOrigin)
+
+	expectedResponseTable := fmt.Sprintf(`New allowed origins: ["https://test1.com", "https://test2.com", "%s"]
+┌──────────┬───────────────┬────────┬────────────────────────────────────────────────────────────────────────────────┐
+│ ID       │ NAME          │ STATUS │ URL                                                                            │
+├──────────┼───────────────┼────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ 2f49c2b3 │ my-data-api-1 │ ready  │ https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql │
+└──────────┴───────────────┴────────┴────────────────────────────────────────────────────────────────────────────────┘
+`, allowedOrigin)
+
+	tests := map[string]struct {
+		mockGetResponse     string
+		mockPatchResponse   string
+		executeCommand      string
+		expectedRequestBody string
+		expectedResponse    string
+	}{
+		"add allowed origin with no existing origins": {
+			mockGetResponse:     mockGetResponseNoOrigins,
+			mockPatchResponse:   mockPatchResponse,
+			executeCommand:      fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId),
+			expectedRequestBody: fmt.Sprintf("{\"security\":{\"cors_policy\":{\"allowed_origins\":[\"%s\"]}}}", allowedOrigin),
+			expectedResponse:    expectedResponseJsonSingleOrigin,
+		},
+		"add allowed origin with existing origins": {
+			mockGetResponse:     mockGetResponseWithOrigins,
+			mockPatchResponse:   mockPatchResponse,
+			executeCommand:      fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId),
+			expectedRequestBody: fmt.Sprintf("{\"security\":{\"cors_policy\":{\"allowed_origins\":[\"https://test1.com\",\"https://test2.com\",\"%s\"]}}}", allowedOrigin),
+			expectedResponse:    expectedResponseJsonMultipleOrigins,
+		},
+		"add existing allowed origin": {
+			mockGetResponse:  mockGetResponseWithExistingOrigin,
+			executeCommand:   fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId),
+			expectedResponse: fmt.Sprintf("Origin already exists in allowed origins: %s\n", allowedOrigin),
+		},
+		"add allowed origin with output table": {
+			mockGetResponse:     mockGetResponseWithOrigins,
+			mockPatchResponse:   mockPatchResponse,
+			executeCommand:      fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s --instance-id %s --data-api-id %s --output table", allowedOrigin, instanceId, dataApiId),
+			expectedRequestBody: fmt.Sprintf("{\"security\":{\"cors_policy\":{\"allowed_origins\":[\"https://test1.com\",\"https://test2.com\",\"%s\"]}}}", allowedOrigin),
+			expectedResponse:    expectedResponseTable,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			helper := testutils.NewAuraTestHelper(t)
+			defer helper.Close()
+
+			helper.SetConfigValue("aura.beta-enabled", true)
+
+			mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, tt.mockGetResponse)
+			mockHandler.AddResponse(http.StatusAccepted, tt.mockPatchResponse)
+
+			helper.ExecuteCommand(tt.executeCommand)
+
+			expectedCalls := 0
+			if tt.mockPatchResponse != "" {
+				expectedCalls += 1
+			}
+			if tt.mockGetResponse != "" {
+				expectedCalls += 1
+			}
+
+			mockHandler.AssertCalledTimes(expectedCalls)
+			if tt.mockGetResponse != "" {
+				mockHandler.AssertCalledWithMethod(http.MethodGet)
+			}
+			if tt.mockPatchResponse != "" {
+				mockHandler.AssertCalledWithMethod(http.MethodPatch)
+				mockHandler.AssertCalledWithBody(tt.expectedRequestBody)
+			}
+
+			helper.AssertOut(tt.expectedResponse)
 		})
 	}
 }

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add_test.go
@@ -137,6 +137,7 @@ func TestAddAllowedOriginWithResponse(t *testing.T) {
 		executeCommand      string
 		expectedRequestBody string
 		expectedResponse    string
+		expectedErr         string
 	}{
 		"add allowed origin with no existing origins": {
 			mockGetResponse:     mockGetResponseNoOrigins,
@@ -153,9 +154,9 @@ func TestAddAllowedOriginWithResponse(t *testing.T) {
 			expectedResponse:    expectedResponseJsonMultipleOrigins,
 		},
 		"add existing allowed origin": {
-			mockGetResponse:  mockGetResponseWithExistingOrigin,
-			executeCommand:   fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId),
-			expectedResponse: fmt.Sprintf("Origin already exists in allowed origins: %s\n", allowedOrigin),
+			mockGetResponse: mockGetResponseWithExistingOrigin,
+			executeCommand:  fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId),
+			expectedErr:     fmt.Sprintf("Error: Origin \"%s\" already exists in allowed origins\n", allowedOrigin),
 		},
 		"add allowed origin with output table": {
 			mockGetResponse:     mockGetResponseWithOrigins,
@@ -196,6 +197,7 @@ func TestAddAllowedOriginWithResponse(t *testing.T) {
 			}
 
 			helper.AssertOut(tt.expectedResponse)
+			helper.AssertErr(tt.expectedErr)
 		})
 	}
 }

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/allowed_origin.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/allowed_origin.go
@@ -15,7 +15,7 @@ import (
 func NewCmd(cfg *clicfg.Config) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "allowed-origin",
-		Short: "Adds an exact Cross-Origin Resource Sharing (CORS) allowed origin for a specific GraphQL Data API",
+		Short: "Allows you to manage Cross-Origin Resource Sharing (CORS) allowed origins for a specific GraphQL Data API",
 	}
 
 	cmd.AddCommand(NewAddCmd(cfg))

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/allowed_origin.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/allowed_origin.go
@@ -1,14 +1,7 @@
 package allowedorigin
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"os"
-
 	"github.com/neo4j/cli/common/clicfg"
-	"github.com/neo4j/cli/common/clierr"
-	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
 	"github.com/spf13/cobra"
 )
 
@@ -22,41 +15,4 @@ func NewCmd(cfg *clicfg.Config) *cobra.Command {
 	cmd.AddCommand(NewRemoveCmd(cfg))
 
 	return cmd
-}
-
-type DetailedBody struct {
-	Data DataBody `json:"data"`
-}
-
-type DataBody struct {
-	Security SecurityBody `json:"security"`
-}
-
-type SecurityBody struct {
-	CorsPolicy CorsPolicyBody `json:"cors_policy"`
-}
-
-type CorsPolicyBody struct {
-	AllowedOrigins []string `json:"allowed_origins"`
-}
-
-func getGetExistingOrigins(cfg *clicfg.Config, dataApiId, instanceId string) ([]string, error) {
-	getPath := fmt.Sprintf("/instances/%s/data-apis/graphql/%s", instanceId, dataApiId)
-	getResBody, statusCode, err := api.MakeRequest(cfg, getPath, &api.RequestConfig{
-		Method: http.MethodGet,
-	})
-	if err != nil {
-		return nil, err
-	}
-	if statusCode != http.StatusOK {
-		panic(clierr.NewFatalError("unexpected status code %d running CLI with args %s, please report an issue in https://github.com/neo4j/cli", statusCode, os.Args[1:]))
-	}
-
-	var parsedGetResBody DetailedBody
-	err = json.Unmarshal(getResBody, &parsedGetResBody)
-	if err != nil {
-		panic(err)
-	}
-
-	return parsedGetResBody.Data.Security.CorsPolicy.AllowedOrigins, nil
 }

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/allowed_origin.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/allowed_origin.go
@@ -19,6 +19,7 @@ func NewCmd(cfg *clicfg.Config) *cobra.Command {
 	}
 
 	cmd.AddCommand(NewAddCmd(cfg))
+	cmd.AddCommand(NewRemoveCmd(cfg))
 
 	return cmd
 }

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/allowed_origin.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/allowed_origin.go
@@ -1,0 +1,61 @@
+package allowedorigin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/neo4j/cli/common/clicfg"
+	"github.com/neo4j/cli/common/clierr"
+	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
+	"github.com/spf13/cobra"
+)
+
+func NewCmd(cfg *clicfg.Config) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "allowed-origin",
+		Short: "Adds an exact Cross-Origin Resource Sharing (CORS) allowed origin for a specific GraphQL Data API",
+	}
+
+	cmd.AddCommand(NewAddCmd(cfg))
+
+	return cmd
+}
+
+type DetailedBody struct {
+	Data DataBody `json:"data"`
+}
+
+type DataBody struct {
+	Security SecurityBody `json:"security"`
+}
+
+type SecurityBody struct {
+	CorsPolicy CorsPolicyBody `json:"cors_policy"`
+}
+
+type CorsPolicyBody struct {
+	AllowedOrigins []string `json:"allowed_origins"`
+}
+
+func getGetExistingOrigins(cfg *clicfg.Config, dataApiId, instanceId string) ([]string, error) {
+	getPath := fmt.Sprintf("/instances/%s/data-apis/graphql/%s", instanceId, dataApiId)
+	getResBody, statusCode, err := api.MakeRequest(cfg, getPath, &api.RequestConfig{
+		Method: http.MethodGet,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusOK {
+		panic(clierr.NewFatalError("unexpected status code %d running CLI with args %s, please report an issue in https://github.com/neo4j/cli", statusCode, os.Args[1:]))
+	}
+
+	var parsedGetResBody DetailedBody
+	err = json.Unmarshal(getResBody, &parsedGetResBody)
+	if err != nil {
+		panic(err)
+	}
+
+	return parsedGetResBody.Data.Security.CorsPolicy.AllowedOrigins, nil
+}

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove.go
@@ -37,7 +37,7 @@ Removing an allowed origin from the CORS policy of a GraphQL Data API means that
 		RunE: func(cmd *cobra.Command, args []string) error {
 			originToRemove := args[0]
 
-			existingOrigins, err := getGetExistingOrigins(cfg, dataApiId, instanceId)
+			existingOrigins, err := getExistingOrigins(cfg, dataApiId, instanceId)
 			if err != nil {
 				return err
 			}

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove.go
@@ -103,10 +103,10 @@ Removing an allowed origin from the CORS policy of a GraphQL Data API means that
 		},
 	}
 
-	cmd.Flags().StringVar(&instanceId, instanceIdFlag, "", "(required) The ID of the instance to create the GraphQL Data API for")
+	cmd.Flags().StringVar(&instanceId, instanceIdFlag, "", "(required) The ID of the instance the GraphQL Data API is connected to")
 	cmd.MarkFlagRequired(instanceIdFlag)
 
-	cmd.Flags().StringVar(&dataApiId, dataApiIdFlag, "", "(required) The ID of the GraphQL Data API to create the authentication provider for")
+	cmd.Flags().StringVar(&dataApiId, dataApiIdFlag, "", "(required) The ID of the GraphQL Data API to remove the CORS allowed origin for")
 	cmd.MarkFlagRequired(dataApiIdFlag)
 
 	cmd.Flags().BoolVar(&await, awaitFlag, false, "Waits until updated GraphQL Data API is ready.")

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/neo4j/cli/common/clicfg"
+	"github.com/neo4j/cli/common/clierr"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/output"
 	"github.com/spf13/cobra"
@@ -53,8 +54,8 @@ Removing an allowed origin from the CORS policy of a GraphQL Data API means that
 			}
 
 			if !originFound {
-				cmd.Println("Origin not found in allowed origins:", originToRemove)
-				return nil
+				cmd.SilenceUsage = true
+				return clierr.NewUsageError("Origin \"%s\" not found in allowed origins", originToRemove)
 			}
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove_test.go
@@ -137,6 +137,7 @@ func TestRemoveAllowedOriginWithResponse(t *testing.T) {
 		executeCommand      string
 		expectedRequestBody string
 		expectedResponse    string
+		expectedErr         string
 	}{
 		"remove allowed origin successfully": {
 			mockGetResponse:     mockGetResponseWithOrigins,
@@ -146,9 +147,9 @@ func TestRemoveAllowedOriginWithResponse(t *testing.T) {
 			expectedResponse:    expectedResponseExistingOrigin,
 		},
 		"remove allowed origin with no existing origins": {
-			mockGetResponse:  mockGetResponseNoOrigins,
-			executeCommand:   fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId),
-			expectedResponse: fmt.Sprintf("Origin not found in allowed origins: %s", allowedOrigin),
+			mockGetResponse: mockGetResponseNoOrigins,
+			executeCommand:  fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId),
+			expectedErr:     fmt.Sprintf("Error: Origin \"%s\" not found in allowed origins", allowedOrigin),
 		},
 		"remove last allowed origin": {
 			mockGetResponse:     mockGetResponseWithLastExistingOrigin,
@@ -196,6 +197,7 @@ func TestRemoveAllowedOriginWithResponse(t *testing.T) {
 			}
 
 			helper.AssertOut(tt.expectedResponse)
+			helper.AssertErr(tt.expectedErr)
 		})
 	}
 }

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove_test.go
@@ -1,0 +1,48 @@
+package allowedorigin_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/neo4j/cli/neo4j-cli/aura/internal/test/testutils"
+)
+
+func TestRemoveAllowedOriginFlagsValidation(t *testing.T) {
+	helper := testutils.NewAuraTestHelper(t)
+	defer helper.Close()
+
+	helper.SetConfigValue("aura.beta-enabled", true)
+
+	instanceId := "2f49c2b3"
+	dataApiId := "e157301d"
+	allowedOrigin := "https://test.com"
+
+	tests := map[string]struct {
+		executedCommand string
+		expectedError   string
+	}{
+		"missing all flags": {
+			executedCommand: fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s", allowedOrigin),
+			expectedError:   "Error: required flag(s) \"data-api-id\", \"instance-id\" not set",
+		},
+		"missing origin": {
+			executedCommand: fmt.Sprintf("data-api graphql cors-policy allowed-origin remove --data-api-id %s --instance-id %s", dataApiId, instanceId),
+			expectedError:   "Error: accepts 1 arg(s), received 0",
+		},
+		"missing data api id flag": {
+			executedCommand: fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s --instance-id %s", allowedOrigin, instanceId),
+			expectedError:   "Error: required flag(s) \"data-api-id\" not set",
+		},
+		"missing instance id flag": {
+			executedCommand: fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s --data-api-id %s", allowedOrigin, dataApiId),
+			expectedError:   "Error: required flag(s) \"instance-id\" not set",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			helper.ExecuteCommand(tt.executedCommand)
+			helper.AssertErr(tt.expectedError)
+		})
+	}
+}

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove_test.go
@@ -2,6 +2,7 @@ package allowedorigin_test
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/test/testutils"
@@ -43,6 +44,158 @@ func TestRemoveAllowedOriginFlagsValidation(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			helper.ExecuteCommand(tt.executedCommand)
 			helper.AssertErr(tt.expectedError)
+		})
+	}
+}
+
+func TestRemoveAllowedOriginWithResponse(t *testing.T) {
+	instanceId := "2f49c2b3"
+	dataApiId := "e157301d"
+	allowedOrigin := "https://test.com"
+
+	mockGetResponseNoOrigins := `{
+		"data": {
+			"id": "2f49c2b3",
+			"name": "my-data-api-1",
+			"status": "ready",
+			"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql",
+			"security": {
+				"cors_policy": {
+					"allowed_origins": []
+				}
+			}
+		}
+	}`
+
+	mockGetResponseWithOrigins := fmt.Sprintf(`{
+		"data": {
+			"id": "2f49c2b3",
+			"name": "my-data-api-1",
+			"status": "ready",
+			"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql",
+			"security": {
+				"cors_policy": {
+					"allowed_origins": ["https://test1.com", "https://test2.com", "%s"]
+				}
+			}
+		}
+	}`, allowedOrigin)
+
+	mockGetResponseWithLastExistingOrigin := fmt.Sprintf(`{
+		"data": {
+			"id": "2f49c2b3",
+			"name": "my-data-api-1",
+			"status": "ready",
+			"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql",
+			"security": {
+				"cors_policy": {
+					"allowed_origins": ["%s"]
+				}
+			}
+		}
+	}`, allowedOrigin)
+
+	mockPatchResponse := `{
+		"data": {
+			"id": "2f49c2b3",
+			"name": "my-data-api-1",
+			"status": "ready",
+			"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql"
+		}
+	}`
+
+	expectedResponseExistingOrigin := `New allowed origins: ["https://test1.com", "https://test2.com"]
+{
+	"data": {
+		"id": "2f49c2b3",
+		"name": "my-data-api-1",
+		"status": "ready",
+		"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql"
+	}
+}`
+	expectedResponseNoRemainingOrigins := `New allowed origins: []
+{
+	"data": {
+		"id": "2f49c2b3",
+		"name": "my-data-api-1",
+		"status": "ready",
+		"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql"
+	}
+}`
+
+	expectedResponseTable := `New allowed origins: ["https://test1.com", "https://test2.com"]
+┌──────────┬───────────────┬────────┬────────────────────────────────────────────────────────────────────────────────┐
+│ ID       │ NAME          │ STATUS │ URL                                                                            │
+├──────────┼───────────────┼────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ 2f49c2b3 │ my-data-api-1 │ ready  │ https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql │
+└──────────┴───────────────┴────────┴────────────────────────────────────────────────────────────────────────────────┘
+`
+
+	tests := map[string]struct {
+		mockGetResponse     string
+		mockPatchResponse   string
+		executeCommand      string
+		expectedRequestBody string
+		expectedResponse    string
+	}{
+		"remove allowed origin successfully": {
+			mockGetResponse:     mockGetResponseWithOrigins,
+			mockPatchResponse:   mockPatchResponse,
+			executeCommand:      fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId),
+			expectedRequestBody: "{\"security\":{\"cors_policy\":{\"allowed_origins\":[\"https://test1.com\",\"https://test2.com\"]}}}",
+			expectedResponse:    expectedResponseExistingOrigin,
+		},
+		"remove allowed origin with no existing origins": {
+			mockGetResponse:  mockGetResponseNoOrigins,
+			executeCommand:   fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId),
+			expectedResponse: fmt.Sprintf("Origin not found in allowed origins: %s", allowedOrigin),
+		},
+		"remove last allowed origin": {
+			mockGetResponse:     mockGetResponseWithLastExistingOrigin,
+			mockPatchResponse:   mockPatchResponse,
+			executeCommand:      fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId),
+			expectedRequestBody: "{\"security\":{\"cors_policy\":{\"allowed_origins\":[]}},\"test\":\"ignore me\"}",
+			expectedResponse:    expectedResponseNoRemainingOrigins,
+		},
+		"remove allowed origin with output table": {
+			mockGetResponse:     mockGetResponseWithOrigins,
+			mockPatchResponse:   mockPatchResponse,
+			executeCommand:      fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s --instance-id %s --data-api-id %s --output table", allowedOrigin, instanceId, dataApiId),
+			expectedRequestBody: "{\"security\":{\"cors_policy\":{\"allowed_origins\":[\"https://test1.com\",\"https://test2.com\"]}}}",
+			expectedResponse:    expectedResponseTable,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			helper := testutils.NewAuraTestHelper(t)
+			defer helper.Close()
+
+			helper.SetConfigValue("aura.beta-enabled", true)
+
+			mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, tt.mockGetResponse)
+			mockHandler.AddResponse(http.StatusAccepted, tt.mockPatchResponse)
+
+			helper.ExecuteCommand(tt.executeCommand)
+
+			expectedCalls := 0
+			if tt.mockPatchResponse != "" {
+				expectedCalls += 1
+			}
+			if tt.mockGetResponse != "" {
+				expectedCalls += 1
+			}
+
+			mockHandler.AssertCalledTimes(expectedCalls)
+			if tt.mockGetResponse != "" {
+				mockHandler.AssertCalledWithMethod(http.MethodGet)
+			}
+			if tt.mockPatchResponse != "" {
+				mockHandler.AssertCalledWithMethod(http.MethodPatch)
+				mockHandler.AssertCalledWithBody(tt.expectedRequestBody)
+			}
+
+			helper.AssertOut(tt.expectedResponse)
 		})
 	}
 }

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/utils.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/utils.go
@@ -1,0 +1,49 @@
+package allowedorigin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/neo4j/cli/common/clicfg"
+	"github.com/neo4j/cli/common/clierr"
+	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
+)
+
+type DetailedBody struct {
+	Data DataBody `json:"data"`
+}
+
+type DataBody struct {
+	Security SecurityBody `json:"security"`
+}
+
+type SecurityBody struct {
+	CorsPolicy CorsPolicyBody `json:"cors_policy"`
+}
+
+type CorsPolicyBody struct {
+	AllowedOrigins []string `json:"allowed_origins"`
+}
+
+func getExistingOrigins(cfg *clicfg.Config, dataApiId, instanceId string) ([]string, error) {
+	getPath := fmt.Sprintf("/instances/%s/data-apis/graphql/%s", instanceId, dataApiId)
+	getResBody, statusCode, err := api.MakeRequest(cfg, getPath, &api.RequestConfig{
+		Method: http.MethodGet,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusOK {
+		panic(clierr.NewFatalError("unexpected status code %d running CLI with args %s, please report an issue in https://github.com/neo4j/cli", statusCode, os.Args[1:]))
+	}
+
+	var parsedGetResBody DetailedBody
+	err = json.Unmarshal(getResBody, &parsedGetResBody)
+	if err != nil {
+		panic(err)
+	}
+
+	return parsedGetResBody.Data.Security.CorsPolicy.AllowedOrigins, nil
+}

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/cors_policy.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/cors_policy.go
@@ -1,0 +1,18 @@
+package corspolicy
+
+import (
+	"github.com/neo4j/cli/common/clicfg"
+	"github.com/neo4j/cli/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin"
+	"github.com/spf13/cobra"
+)
+
+func NewCmd(cfg *clicfg.Config) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "cors-policy",
+		Short: "Allows you to manage the Cross-Origin Resource Sharing (CORS) policy for a specific GraphQL Data API",
+	}
+
+	cmd.AddCommand(allowedorigin.NewCmd(cfg))
+
+	return cmd
+}

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/create.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/create.go
@@ -118,7 +118,7 @@ If you lose your API key, you will need to create a new Authentication provider.
 
 	cmd.Flags().StringVar(&typeDefs, typeDefsFlag, "", "The GraphQL type definitions, NOTE: must be base64 encoded")
 
-	cmd.Flags().StringVar(&typeDefsFile, typeDefsFileFlag, "", "Path to a local GraphQL type definitions file, e.x. path/to/typeDefs.graphql. Must be of file type .graphql")
+	cmd.Flags().StringVar(&typeDefsFile, typeDefsFileFlag, "", "Path to a local GraphQL type definitions file, e.g. path/to/typeDefs.graphql. Must be of file type .graphql")
 	cmd.MarkFlagsMutuallyExclusive(typeDefsFlag, typeDefsFileFlag)
 	cmd.MarkFlagsOneRequired(typeDefsFlag, typeDefsFileFlag)
 

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/delete.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/delete.go
@@ -37,7 +37,7 @@ func NewDeleteCmd(cfg *clicfg.Config) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&instanceId, "instance-id", "", "The ID of the instance to delete the Data API for")
+	cmd.Flags().StringVar(&instanceId, "instance-id", "", "(required) The ID of the instance to delete the Data API for")
 	cmd.MarkFlagRequired("instance-id")
 
 	return cmd

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/get.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/get.go
@@ -36,7 +36,7 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&instanceId, "instance-id", "", "The ID of the instance to get the GraphQL Data API details for")
+	cmd.Flags().StringVar(&instanceId, "instance-id", "", "(required) The ID of the instance to get the GraphQL Data API details for")
 	cmd.MarkFlagRequired("instance-id")
 
 	return cmd

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/graphql.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/graphql.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/subcommands/dataapi/graphql/authprovider"
+	"github.com/neo4j/cli/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy"
 )
 
 func NewCmd(cfg *clicfg.Config) *cobra.Command {
@@ -14,6 +15,7 @@ func NewCmd(cfg *clicfg.Config) *cobra.Command {
 	}
 
 	cmd.AddCommand(authprovider.NewCmd(cfg))
+	cmd.AddCommand(corspolicy.NewCmd(cfg))
 	cmd.AddCommand(NewListCmd(cfg))
 	cmd.AddCommand(NewGetCmd(cfg))
 	cmd.AddCommand(NewUpdateCmd(cfg))

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/list.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/list.go
@@ -31,7 +31,7 @@ func NewListCmd(cfg *clicfg.Config) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&instanceId, "instance-id", "", "The ID of the instance to list the GraphQL Data APIs of")
+	cmd.Flags().StringVar(&instanceId, "instance-id", "", "(required) The ID of the instance to list the GraphQL Data APIs of")
 	cmd.MarkFlagRequired("instance-id")
 
 	return cmd

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/pause.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/pause.go
@@ -52,7 +52,7 @@ Pausing a GraphQL Data API is an asynchronous operation. Use the --await flag to
 		},
 	}
 
-	cmd.Flags().StringVar(&instanceId, "instance-id", "", "The ID of the instance to pause the Data API for")
+	cmd.Flags().StringVar(&instanceId, "instance-id", "", "(required) The ID of the instance to pause the Data API for")
 	cmd.MarkFlagRequired("instance-id")
 
 	cmd.Flags().BoolVar(&await, "await", false, "Waits until GraphQL Data API is paused.")

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/resume.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/resume.go
@@ -52,7 +52,7 @@ Resuming a GraphQL Data API is an asynchronous operation. Use the --await flag t
 		},
 	}
 
-	cmd.Flags().StringVar(&instanceId, "instance-id", "", "The ID of the instance to resume the Data API for")
+	cmd.Flags().StringVar(&instanceId, "instance-id", "", "(required) The ID of the instance to resume the Data API for")
 	cmd.MarkFlagRequired("instance-id")
 
 	cmd.Flags().BoolVar(&await, "await", false, "Waits until GraphQL Data API is resumed.")

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/update.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/update.go
@@ -106,7 +106,7 @@ Updating a GraphQL Data API is an asynchronous operation. Use the --await flag t
 
 	cmd.Flags().StringVar(&typeDefs, typeDefsFlag, "", "The GraphQL type definitions, NOTE: must be base64 encoded")
 
-	cmd.Flags().StringVar(&typeDefsFile, typeDefsFileFlag, "", "Path to a local GraphQL type definitions file, e.x. path/to/typeDefs.graphql")
+	cmd.Flags().StringVar(&typeDefsFile, typeDefsFileFlag, "", "Path to a local GraphQL type definitions file, e.g. path/to/typeDefs.graphql")
 	cmd.MarkFlagsMutuallyExclusive(typeDefsFlag, typeDefsFileFlag)
 
 	cmd.Flags().BoolVar(&await, awaitFlag, false, "Waits until updated GraphQL Data API is ready again.")


### PR DESCRIPTION
Adds commands to add/remove allowed origins from the CORS policy of a Data API