### PR TITLE
chore: Aura api version rework - disregard version number

### DIFF
--- a/common/clicfg/clicfg.go
+++ b/common/clicfg/clicfg.go
@@ -154,12 +154,10 @@ func removePathParametersFromUrl(originalUrl string) string {
 }
 
 func (config *AuraConfig) BetaPathV1() string {
-	//TBD: if we allow users to config the beta path
 	return "v1beta5"
 }
 
 func (config *AuraConfig) BetaPathV2() string {
-	//TBD: if we allow users to config the beta path
 	return "v2beta1"
 }
 

--- a/common/clicfg/clicfg.go
+++ b/common/clicfg/clicfg.go
@@ -151,7 +151,6 @@ func (config *AuraConfig) BaseUrl() string {
 	log.Printf("aura.base-url: %s", parsedUrl.Host)
 	log.Printf("aura.auth-url: %s", parsedUrl.Scheme)
 	return fmt.Sprintf("%s://%s", parsedUrl.Scheme, parsedUrl.Host)
-	//return originalUrl.(string)
 }
 
 func (config *AuraConfig) BetaPathV1() string {

--- a/common/clicfg/clicfg.go
+++ b/common/clicfg/clicfg.go
@@ -120,14 +120,10 @@ func (config *AuraConfig) Set(key string, value string) {
 		panic(err)
 	}
 
-	baseUrlToUpdate := ""
 	if key == "base-url" {
-		baseUrlToUpdate = value
-	}
-	log.Printf("updating aura base url: %s", updateConfig)
-	updatedAuraBaseUrl := config.auraBaseUrlOnConfigChange(baseUrlToUpdate)
-	log.Printf("updated aura base url: %s", updatedAuraBaseUrl)
-	if updatedAuraBaseUrl != "" {
+		log.Printf("updating aura base url: %s", updateConfig)
+		updatedAuraBaseUrl := config.auraBaseUrlOnConfigChange(value)
+		log.Printf("updated aura base url: %s", updatedAuraBaseUrl)
 		intermediateUpdateConfig, err := sjson.Set(string(updateConfig), "aura.base-url", updatedAuraBaseUrl)
 		if err != nil {
 			panic(err)
@@ -149,8 +145,10 @@ func (config *AuraConfig) Print(cmd *cobra.Command) {
 }
 
 func (config *AuraConfig) BaseUrl() string {
-	originalUrl := config.viper.Get("aura.base-url")
-	return removePathParametersFromUrl(originalUrl.(string))
+	originalUrl := config.viper.GetString("aura.base-url")
+	//Existing users have base url configs with trailing path /v1.
+	//To make it backward compatible, we allow old config and clear up by removing trailing path /v1 in the url
+	return removePathParametersFromUrl(originalUrl)
 }
 
 func removePathParametersFromUrl(originalUrl string) string {

--- a/common/clicfg/clicfg.go
+++ b/common/clicfg/clicfg.go
@@ -21,8 +21,6 @@ var ConfigPrefix string
 
 const (
 	DefaultAuraBaseUrl     = "https://api.neo4j.io"
-	DefaultAuraBetaPathV1  = "v1beta5"
-	DefaultAuraBetaPathV2  = "v2beta1"
 	DefaultAuraAuthUrl     = "https://api.neo4j.io/oauth/token"
 	DefaultAuraBetaEnabled = false
 )
@@ -162,11 +160,13 @@ func removePathParametersFromUrl(originalUrl string) string {
 }
 
 func (config *AuraConfig) BetaPathV1() string {
-	return DefaultAuraBetaPathV1
+	//TBD: if we allow users to config the beta path
+	return "v1beta5"
 }
 
 func (config *AuraConfig) BetaPathV2() string {
-	return DefaultAuraBetaPathV2
+	//TBD: if we allow users to config the beta path
+	return "v2beta1"
 }
 
 func (config *AuraConfig) BindBaseUrl(flag *pflag.Flag) {

--- a/common/clicfg/clicfg.go
+++ b/common/clicfg/clicfg.go
@@ -3,7 +3,6 @@ package clicfg
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/url"
 	"path/filepath"
 	"slices"
@@ -119,15 +118,12 @@ func (config *AuraConfig) Set(key string, value string) {
 	}
 
 	if key == "base-url" {
-		log.Printf("updating aura base url: %s", updateConfig)
 		updatedAuraBaseUrl := config.auraBaseUrlOnConfigChange(value)
-		log.Printf("updated aura base url: %s", updatedAuraBaseUrl)
 		intermediateUpdateConfig, err := sjson.Set(string(updateConfig), "aura.base-url", updatedAuraBaseUrl)
 		if err != nil {
 			panic(err)
 		}
 		updateConfig = intermediateUpdateConfig
-		log.Printf("updated aura config: %s", updateConfig)
 	}
 
 	fileutils.WriteFile(config.fs, filename, []byte(updateConfig))
@@ -154,8 +150,6 @@ func removePathParametersFromUrl(originalUrl string) string {
 	if err != nil {
 		panic(err)
 	}
-	log.Printf("aura.base-url: %s", parsedUrl.Host)
-	log.Printf("aura.auth-url: %s", parsedUrl.Scheme)
 	return fmt.Sprintf("%s://%s", parsedUrl.Scheme, parsedUrl.Host)
 }
 

--- a/common/clicfg/clicfg.go
+++ b/common/clicfg/clicfg.go
@@ -120,7 +120,7 @@ func (config *AuraConfig) Set(key string, value string) {
 		panic(err)
 	}
 
-	updatedAuraBaseUrl := config.auraBaseUrlOnBetaEnabledChange(key, value)
+	updatedAuraBaseUrl := config.auraBaseUrlOnBetaEnabledChange()
 	if updatedAuraBaseUrl != "" {
 		intermediateUpdateConfig, err := sjson.Set(string(updateConfig), "aura.base-url", updatedAuraBaseUrl)
 		if err != nil {
@@ -151,6 +151,7 @@ func (config *AuraConfig) BaseUrl() string {
 	log.Printf("aura.base-url: %s", parsedUrl.Host)
 	log.Printf("aura.auth-url: %s", parsedUrl.Scheme)
 	return fmt.Sprintf("%s://%s", parsedUrl.Scheme, parsedUrl.Host)
+	//return originalUrl.(string)
 }
 
 func (config *AuraConfig) BetaPathV1() string {
@@ -210,13 +211,9 @@ func (config *AuraConfig) SetPollingConfig(maxRetries int, interval int) {
 	}
 }
 
-func (config *AuraConfig) auraBaseUrlOnBetaEnabledChange(key string, value string) string {
-	if key == "beta-enabled" {
-		nextBaseUrl := DefaultAuraBaseUrl
-		if value == "true" {
-			nextBaseUrl = DefaultAuraBetaPathV1
-		}
-		return nextBaseUrl
+func (config *AuraConfig) auraBaseUrlOnBetaEnabledChange() string {
+	if config.BaseUrl() == "" {
+		return DefaultAuraBaseUrl
 	}
-	return ""
+	return config.BaseUrl()
 }

--- a/common/clicfg/clicfg_test.go
+++ b/common/clicfg/clicfg_test.go
@@ -38,5 +38,5 @@ func TestGetAuraBaseUrlConfig(t *testing.T) {
 	cfg := clicfg.NewConfig(fs, "test")
 
 	//The path parameter will be removed from GET base url
-	assert.Equal(t, cfg.Aura.BaseUrl(), server.URL)
+	assert.Equal(t, server.URL, cfg.Aura.BaseUrl())
 }

--- a/common/clicfg/clicfg_test.go
+++ b/common/clicfg/clicfg_test.go
@@ -1,0 +1,42 @@
+package clicfg_test
+
+import (
+	"fmt"
+	"github.com/neo4j/cli/common/clicfg"
+	"github.com/neo4j/cli/test/utils/testfs"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetAuraBaseUrlConfig(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+
+	cfgStr := fmt.Sprintf(`{
+		"aura": {
+			"auth-url": "%s/oauth/token",
+			"base-url": "%s/v1",
+			"output": "json"
+			}
+		}`, server.URL, server.URL)
+
+	credentialsStr := `{
+		"aura": {
+			"credentials": [{
+				"name": "test-cred",
+				"access-token": "dsa",
+				"token-expiry": 123
+			}],
+			"default-credential": "test-cred"
+			}
+		}`
+
+	fs, err := testfs.GetTestFs(cfgStr, credentialsStr)
+	assert.Nil(t, err)
+	cfg := clicfg.NewConfig(fs, "test")
+
+	//The path parameter will be removed from GET base url
+	assert.Equal(t, cfg.Aura.BaseUrl(), server.URL)
+}

--- a/common/clicfg/clicfg_test.go
+++ b/common/clicfg/clicfg_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestGetAuraBaseUrlConfig(t *testing.T) {
+func TestGetAuraBaseUrlConfigRemovesTrailingPath(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 

--- a/neo4j-cli/aura/internal/api/api.go
+++ b/neo4j-cli/aura/internal/api/api.go
@@ -98,18 +98,20 @@ func MakeRequest(cfg *clicfg.Config, path string, config *RequestConfig) (respon
 func getVersionPath(cfg *clicfg.Config, version AuraApiVersion) string {
 	betaEnabled := cfg.Aura.AuraBetaEnabled()
 
-	if version == AuraApiVersion1 {
+	switch version {
+	case AuraApiVersion1:
 		if betaEnabled {
 			return cfg.Aura.BetaPathV1()
 		}
-		return "/v1"
-	} else if version == AuraApiVersion2 {
+		return "v1"
+	case AuraApiVersion2:
 		if betaEnabled {
 			return cfg.Aura.BetaPathV2()
 		}
-		return "/v2"
+		return "v2"
+	default:
+		panic(fmt.Sprintf("version not set in requests %s", version))
 	}
-	return ""
 }
 
 func createBody(data map[string]any) io.Reader {

--- a/neo4j-cli/aura/internal/api/api.go
+++ b/neo4j-cli/aura/internal/api/api.go
@@ -2,11 +2,9 @@ package api
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 
@@ -35,7 +33,6 @@ type RequestConfig struct {
 }
 
 func MakeRequest(cfg *clicfg.Config, path string, config *RequestConfig) (responseBody []byte, statusCode int, err error) {
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	client := http.Client{}
 	var method = config.Method
 	if method == "" {
@@ -48,7 +45,6 @@ func MakeRequest(cfg *clicfg.Config, path string, config *RequestConfig) (respon
 	if config.Version == "" {
 		config.Version = AuraApiVersion1
 	}
-	log.Printf("aura.base-url: %s", baseUrl)
 	versionPath := getVersionPath(cfg, config.Version)
 
 	u, _ := url.ParseRequestURI(baseUrl)
@@ -58,7 +54,6 @@ func MakeRequest(cfg *clicfg.Config, path string, config *RequestConfig) (respon
 	addQueryParams(u, config.QueryParams)
 
 	urlString := u.String()
-	log.Printf("aura.url-string: %s", urlString)
 	req, err := http.NewRequest(method, urlString, body)
 
 	if err != nil {

--- a/neo4j-cli/aura/internal/subcommands/config/set.go
+++ b/neo4j-cli/aura/internal/subcommands/config/set.go
@@ -4,6 +4,7 @@ import (
 	"github.com/neo4j/cli/common/clicfg"
 	"github.com/neo4j/cli/common/clierr"
 	"github.com/spf13/cobra"
+	"log"
 )
 
 func NewSetCmd(cfg *clicfg.Config) *cobra.Command {
@@ -35,6 +36,7 @@ func NewSetCmd(cfg *clicfg.Config) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Printf("args: %v", args)
 			cfg.Aura.Set(args[0], args[1])
 
 			return nil

--- a/neo4j-cli/aura/internal/subcommands/config/set.go
+++ b/neo4j-cli/aura/internal/subcommands/config/set.go
@@ -4,7 +4,6 @@ import (
 	"github.com/neo4j/cli/common/clicfg"
 	"github.com/neo4j/cli/common/clierr"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 func NewSetCmd(cfg *clicfg.Config) *cobra.Command {
@@ -36,7 +35,6 @@ func NewSetCmd(cfg *clicfg.Config) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Printf("args: %v", args)
 			cfg.Aura.Set(args[0], args[1])
 
 			return nil

--- a/neo4j-cli/aura/internal/subcommands/config/set_test.go
+++ b/neo4j-cli/aura/internal/subcommands/config/set_test.go
@@ -47,11 +47,11 @@ func TestSetBetaEnabledConfig(t *testing.T) {
 
 	helper.ExecuteCommand("config set beta-enabled true")
 
-	helper.AssertConfigValue("aura.base-url", "https://api.neo4j.io/v1beta5")
+	helper.AssertConfigValue("aura.base-url", "https://api.neo4j.io")
 	helper.AssertConfigValue("aura.beta-enabled", "true")
 
 	helper.ExecuteCommand("config set beta-enabled false")
 
-	helper.AssertConfigValue("aura.base-url", "https://api.neo4j.io/v1")
+	helper.AssertConfigValue("aura.base-url", "https://api.neo4j.io")
 	helper.AssertConfigValue("aura.beta-enabled", "false")
 }

--- a/neo4j-cli/aura/internal/subcommands/config/set_test.go
+++ b/neo4j-cli/aura/internal/subcommands/config/set_test.go
@@ -47,11 +47,9 @@ func TestSetBetaEnabledConfig(t *testing.T) {
 
 	helper.ExecuteCommand("config set beta-enabled true")
 
-	helper.AssertConfigValue("aura.base-url", "https://api.neo4j.io")
 	helper.AssertConfigValue("aura.beta-enabled", "true")
 
 	helper.ExecuteCommand("config set beta-enabled false")
 
-	helper.AssertConfigValue("aura.base-url", "https://api.neo4j.io")
 	helper.AssertConfigValue("aura.beta-enabled", "false")
 }

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/authprovider/create_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/authprovider/create_test.go
@@ -171,7 +171,7 @@ func TestCreateAuthProviderWithResponse(t *testing.T) {
 
 			helper.SetConfigValue("aura.beta-enabled", true)
 
-			mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s/auth-providers", instanceId, dataApiId), http.StatusAccepted, tt.mockResponse)
+			mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s/auth-providers", instanceId, dataApiId), http.StatusAccepted, tt.mockResponse)
 
 			helper.ExecuteCommand(tt.executeCommand)
 

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/authprovider/delete_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/authprovider/delete_test.go
@@ -17,7 +17,7 @@ func TestDeleteAuthProvider(t *testing.T) {
 	instanceId := "2f49c2b3"
 	dataApiId := "a342b824"
 	authProviderId := "87d46b4b-3bfb-4ad2-8dac-0e95cf72d39f"
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s/auth-providers/%s", instanceId, dataApiId, authProviderId), http.StatusAccepted, `{
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s/auth-providers/%s", instanceId, dataApiId, authProviderId), http.StatusAccepted, `{
 		"data": {
 			"id": "87d46b4b-3bfb-4ad2-8dac-0e95cf72d39f",
 			"name": "test-key",

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/authprovider/get_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/authprovider/get_test.go
@@ -17,7 +17,7 @@ func TestGetAuthProvider(t *testing.T) {
 	instanceId := "2f49c2b3"
 	dataApiId := "a342b824"
 	authProviderId := "87d46b4b-3bfb-4ad2-8dac-0e95cf72d39f"
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s/auth-providers/%s", instanceId, dataApiId, authProviderId), http.StatusOK, `{
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s/auth-providers/%s", instanceId, dataApiId, authProviderId), http.StatusOK, `{
 		"data": {
 			"id": "87d46b4b-3bfb-4ad2-8dac-0e95cf72d39f",
 			"name": "test-key",

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/authprovider/list_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/authprovider/list_test.go
@@ -16,7 +16,7 @@ func TestListAuthProviders(t *testing.T) {
 
 	instanceId := "2f49c2b3"
 	dataApiId := "a342b824"
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s/auth-providers", instanceId, dataApiId), http.StatusOK, `{
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s/auth-providers", instanceId, dataApiId), http.StatusOK, `{
 		"data": [
 			{
 				"id": "87d46b4b-3bfb-4ad2-8dac-0e95cf72d39f",

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add_test.go
@@ -88,7 +88,7 @@ func TestAddAllowedOriginWithNoExistingOrigins(t *testing.T) {
 
 	helper.SetConfigValue("aura.beta-enabled", true)
 
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
 	mockHandler.AddResponse(http.StatusAccepted, mockPatchResponse)
 
 	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId))
@@ -131,7 +131,7 @@ func TestAddAllowedOriginWithExistingOrigins(t *testing.T) {
 
 	helper.SetConfigValue("aura.beta-enabled", true)
 
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
 	mockHandler.AddResponse(http.StatusAccepted, mockPatchResponse)
 
 	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId))
@@ -164,7 +164,7 @@ func TestAddAllowedOriginWithDuplicateOrigin(t *testing.T) {
 
 	helper.SetConfigValue("aura.beta-enabled", true)
 
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
 	mockHandler.AddResponse(http.StatusAccepted, mockPatchResponse)
 
 	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId))
@@ -202,7 +202,7 @@ func TestAddAllowedOriginWithOutputTable(t *testing.T) {
 
 	helper.SetConfigValue("aura.beta-enabled", true)
 
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
 	mockHandler.AddResponse(http.StatusAccepted, mockPatchResponse)
 
 	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin add %s --instance-id %s --data-api-id %s --output table", allowedOrigin, instanceId, dataApiId))

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove_test.go
@@ -73,7 +73,7 @@ func TestRemoveAllowedOriginWithRemainingOrigins(t *testing.T) {
 
 	helper.SetConfigValue("aura.beta-enabled", true)
 
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
 	mockHandler.AddResponse(http.StatusAccepted, mockPatchResponse)
 
 	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId))
@@ -107,7 +107,7 @@ func TestRemoveAllowedOriginWithNoExistingOrigins(t *testing.T) {
 
 	helper.SetConfigValue("aura.beta-enabled", true)
 
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
 	mockHandler.AddResponse(http.StatusAccepted, mockPatchResponse)
 
 	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId))
@@ -147,7 +147,7 @@ func TestRemoveAllowedOriginLastAllowedOrigin(t *testing.T) {
 
 	helper.SetConfigValue("aura.beta-enabled", true)
 
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
 	mockHandler.AddResponse(http.StatusAccepted, mockPatchResponse)
 
 	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s --instance-id %s --data-api-id %s", allowedOrigin, instanceId, dataApiId))
@@ -188,7 +188,7 @@ func TestRemoveAllowedOriginWithOutputTable(t *testing.T) {
 
 	helper.SetConfigValue("aura.beta-enabled", true)
 
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
 	mockHandler.AddResponse(http.StatusAccepted, mockPatchResponse)
 
 	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin remove %s --instance-id %s --data-api-id %s --output table", allowedOrigin, instanceId, dataApiId))

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/create_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/create_test.go
@@ -158,7 +158,7 @@ func TestCreateGraphQLDataApiWithResponse(t *testing.T) {
 
 			helper.SetConfigValue("aura.beta-enabled", true)
 
-			mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql", instanceId), http.StatusAccepted, tt.mockResponse)
+			mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql", instanceId), http.StatusAccepted, tt.mockResponse)
 
 			helper.ExecuteCommand(tt.executeCommand)
 

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/delete_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/delete_test.go
@@ -16,7 +16,7 @@ func TestDeleteGraphQLDataApi(t *testing.T) {
 
 	instanceId := "2f49c2b3"
 	dataApiId := "afdb4e9d"
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusAccepted, `{
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusAccepted, `{
 			"data": {
                 "id": "afdb4e9d",
                 "name": "friendly-name",

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/get_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/get_test.go
@@ -16,7 +16,7 @@ func TestGetGraphQLDataApi(t *testing.T) {
 
 	instanceId := "2f49c2b3"
 	dataApiId := "afdb4e9d"
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, `{
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, `{
 			"data": {
                 "features": {
                         "subgraph": false
@@ -56,7 +56,7 @@ func TestGetGraphQLDataApiIncludingGraphQLServerErrors(t *testing.T) {
 
 	instanceId := "2f49c2b3"
 	dataApiId := "afdb4e9d"
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, `{
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, `{
 			"data": {
                 "features": {
                         "subgraph": false

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/list_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/list_test.go
@@ -15,7 +15,7 @@ func TestListGraphQLDataApis(t *testing.T) {
 	helper.SetConfigValue("aura.beta-enabled", true)
 
 	instanceId := "2f49c2b3"
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql", instanceId), http.StatusOK, `{
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql", instanceId), http.StatusOK, `{
 		"data": [
 			{
 				"id": "7261d20a",

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/pause_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/pause_test.go
@@ -16,7 +16,7 @@ func TestPauseGraphQLDataApi(t *testing.T) {
 
 	instanceId := "2f49c2b3"
 	dataApiId := "afdb4e9d"
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s/pause", instanceId, dataApiId), http.StatusAccepted, `{
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s/pause", instanceId, dataApiId), http.StatusAccepted, `{
 			"data": {
                 "id": "afdb4e9d",
                 "name": "friendly-name",

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/resume_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/resume_test.go
@@ -16,7 +16,7 @@ func TestResumeGraphQLDataApi(t *testing.T) {
 
 	instanceId := "2f49c2b3"
 	dataApiId := "afdb4e9d"
-	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s/resume", instanceId, dataApiId), http.StatusAccepted, `{
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s/resume", instanceId, dataApiId), http.StatusAccepted, `{
 			"data": {
                 "id": "afdb4e9d",
                 "name": "friendly-name",

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/update_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/update_test.go
@@ -110,7 +110,7 @@ func TestUpdateGraphQLDataApiWithResponse(t *testing.T) {
 
 			helper.SetConfigValue("aura.beta-enabled", true)
 
-			mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusAccepted, tt.mockResponse)
+			mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusAccepted, tt.mockResponse)
 
 			helper.ExecuteCommand(tt.executeCommand)
 

--- a/neo4j-cli/aura/internal/test/testutils/auratesthelper.go
+++ b/neo4j-cli/aura/internal/test/testutils/auratesthelper.go
@@ -147,7 +147,8 @@ func (helper *AuraTestHelper) AssertConfigValue(key string, expected string) {
 	out, err := io.ReadAll(file)
 	assert.Nil(helper.t, err)
 
-	actual := gjson.Get(string(out), key)
+	strOut := string(out)
+	actual := gjson.Get(strOut, key)
 
 	formattedExpected, err := FormatJson(expected, "\t")
 	if err != nil {


### PR DESCRIPTION
Redesign the V1/V2 version handling for endpoints: The base URL of Aura Cli contains versions. To make it more generic, we should clear up the old URL to keep the domain only, and internally maintain the version.

Current:

```
{
        "auth-url": "https://api-devjun2.neo4j-dev.io/oauth/token",
        "base-url": "https://api-devjun2.neo4j-dev.io/v1",
        "beta-enabled": false,
        "output": "default"
}
```

In the new implementation, the `v1` path parameter will be disregarded. When setting a new base URL value, the path parameters will be disregarded too.
In subsequent PRs. there will be clean ups on user's configuration content to remove path parameters.