### PR TITLE
Fix for issue #108

### DIFF
--- a/.changes/unreleased/Fixed-20250812-165812.yaml
+++ b/.changes/unreleased/Fixed-20250812-165812.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'fix for https://github.com/neo4j/aura-cli/issues/108 where using config set on first ever execution causes a crash.  '
+time: 2025-08-12T16:58:12.271578+01:00


### PR DESCRIPTION
Changes in clicfg.go 

Viper.ReadInConfig() didn't fail if the config file did not exist.  This resulted in code to create the file not being run.   When the cli is executed for the first time and the config file does not exist, this causes a crash when the config set command is used

Changed to use fileutils.FileExists to detect if file exists, and if not, create the file path and the file ( Viper.SafeWriteConfig(); 


Viper.ReadInConfig() is called afterwards to populate the viper config


