### PR TITLE
Fix for issue #108

### DIFF
--- a/.changes/unreleased/Fixed-20250813-113459.yaml
+++ b/.changes/unreleased/Fixed-20250813-113459.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'Fix for issue #108 where running aura-cli for the first time to set a config value causes a panic'
+time: 2025-08-13T11:34:59.820531+01:00


### PR DESCRIPTION
Takes care of a panic that happens when aura-cli has never been run before and the first use is to set a config value. 