### PR TITLE
Change changie kinds

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -4,20 +4,14 @@ headerPath: header.tpl.md
 changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
-kindFormat: '### {{.Kind}}'
-changeFormat: '* {{.Body}}'
+kindFormat: "### {{.Kind}}"
+changeFormat: "* {{.Body}}"
 kinds:
-    - label: Added
-      auto: minor
-    - label: Changed
+    - label: Major
       auto: major
-    - label: Deprecated
+    - label: Minor
       auto: minor
-    - label: Removed
-      auto: major
-    - label: Fixed
-      auto: patch
-    - label: Security
+    - label: Patch
       auto: patch
 newlines:
     afterChangelogHeader: 1


### PR DESCRIPTION
This changes changie to use Major Minor Patch, instead of the default labels

NOTE: this should not be merged until all the changie files are cleared in a release