### PR TITLE
Run changie workflow only when unreleased changes are present

### DIFF
--- a/.github/workflows/changie.yml
+++ b/.github/workflows/changie.yml
@@ -3,6 +3,8 @@ name: changie
 on:
   push:
     branches: ["main"]
+    paths:
+      - ".changes/unreleased/**"
 
 jobs:
   generate-pr:


### PR DESCRIPTION
The changie workflow currently runs at every push on the main branch. This fails when no changes are present; this change causes the flow to run only when changes are detected on the unreleased path. See: https://github.com/neo4j/aura-cli/actions/workflows/changie.yml