### PR TITLE
Fix newline JSON unmarshalling bug

### DIFF
--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add.go
@@ -38,7 +38,7 @@ Updating the CORS policy of a GraphQL Data API is an asynchronous operation. Use
 Adding a new allowed origin to the CORS policy of a GraphQL Data API allows browsers to make requests to the GraphQL Data API from a web app that is served from the specified origin.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			newOrigin := args[0]
+			newOrigin := strings.TrimSpace(args[0])
 
 			existingOrigins, err := getExistingOrigins(cfg, dataApiId, instanceId)
 			if err != nil {

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove.go
@@ -38,7 +38,7 @@ Updating the CORS policy of a GraphQL Data API is an asynchronous operation. Use
 Removing an allowed origin from the CORS policy of a GraphQL Data API means that most browsers are no longer able to make requests to the GraphQL Data API from a web app that is served from the specified origin.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			originToRemove := args[0]
+			originToRemove := strings.TrimSpace(args[0])
 
 			existingOrigins, err := getExistingOrigins(cfg, dataApiId, instanceId)
 			if err != nil {

--- a/neo4j-cli/aura/internal/subcommands/deployment/delete.go
+++ b/neo4j-cli/aura/internal/subcommands/deployment/delete.go
@@ -6,6 +6,7 @@ package deployment
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/neo4j/cli/common/clicfg"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
@@ -38,7 +39,7 @@ func NewDeleteCmd(cfg *clicfg.Config) *cobra.Command {
 				return err
 			}
 
-			deploymentId := args[0]
+			deploymentId := strings.TrimSpace(args[0])
 			path := fmt.Sprintf("/organizations/%s/projects/%s/fleet-manager/deployments/%s", organizationId, projectId, deploymentId)
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/deployment/get.go
+++ b/neo4j-cli/aura/internal/subcommands/deployment/get.go
@@ -6,6 +6,7 @@ package deployment
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/neo4j/cli/common/clicfg"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
@@ -39,7 +40,7 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 				return err
 			}
 
-			deploymentId := args[0]
+			deploymentId := strings.TrimSpace(args[0])
 			path := fmt.Sprintf("/organizations/%s/projects/%s/fleet-manager/deployments/%s", organizationId, projectId, deploymentId)
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/import/job/cancel.go
+++ b/neo4j-cli/aura/internal/subcommands/import/job/cancel.go
@@ -6,6 +6,7 @@ package job
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/neo4j/cli/common/clicfg"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
@@ -39,7 +40,7 @@ func NewCancelCommand(cfg *clicfg.Config) *cobra.Command {
 				return err
 			}
 
-			jobId = args[0]
+			jobId = strings.TrimSpace(args[0])
 			path := fmt.Sprintf("/organizations/%s/projects/%s/import/jobs/%s/cancellation", organizationId, projectId, jobId)
 			resBody, statusCode, err := api.MakeRequest(cfg, path, &api.RequestConfig{
 				Method:  http.MethodPost,

--- a/neo4j-cli/aura/internal/subcommands/import/job/get.go
+++ b/neo4j-cli/aura/internal/subcommands/import/job/get.go
@@ -6,6 +6,7 @@ package job
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/neo4j/cli/common/clicfg"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
@@ -41,7 +42,7 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 				return err
 			}
 
-			jobId = args[0]
+			jobId = strings.TrimSpace(args[0])
 			path := fmt.Sprintf("/organizations/%s/projects/%s/import/jobs/%s", organizationId, projectId, jobId)
 
 			resBody, statusCode, err := api.MakeRequest(cfg, path, &api.RequestConfig{

--- a/neo4j-cli/aura/internal/subcommands/instance/get.go
+++ b/neo4j-cli/aura/internal/subcommands/instance/get.go
@@ -6,6 +6,7 @@ package instance
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -21,7 +22,8 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 		Long:  "This endpoint returns details about a specific Aura Instance.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			instanceId := args[0]
+			instanceId := strings.TrimSpace(args[0])
+
 			path := fmt.Sprintf("/instances/%s", instanceId)
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/instance/get.go
+++ b/neo4j-cli/aura/internal/subcommands/instance/get.go
@@ -23,7 +23,6 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			instanceId := strings.TrimSpace(args[0])
-
 			path := fmt.Sprintf("/instances/%s", instanceId)
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/instance/overwrite.go
+++ b/neo4j-cli/aura/internal/subcommands/instance/overwrite.go
@@ -6,6 +6,7 @@ package instance
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/neo4j/cli/common/clicfg"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
@@ -36,7 +37,7 @@ If only --source-instance-id is provided, a new snapshot of that instance is cre
 		`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			instanceId := args[0]
+			instanceId := strings.TrimSpace(args[0])
 			path := fmt.Sprintf("/instances/%s/overwrite", instanceId)
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/tenant/get.go
+++ b/neo4j-cli/aura/internal/subcommands/tenant/get.go
@@ -24,7 +24,6 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			tenantId := strings.TrimSpace(args[0])
-
 			path := fmt.Sprintf("/tenants/%s", tenantId)
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/tenant/get.go
+++ b/neo4j-cli/aura/internal/subcommands/tenant/get.go
@@ -6,6 +6,7 @@ package tenant
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -22,7 +23,8 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 		Long:  "This subcommand returns details about a specific Aura Tenant.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tenantId := args[0]
+			tenantId := strings.TrimSpace(args[0])
+
 			path := fmt.Sprintf("/tenants/%s", tenantId)
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/tenant/get_test.go
+++ b/neo4j-cli/aura/internal/subcommands/tenant/get_test.go
@@ -112,6 +112,46 @@ func TestGetTenantNotFoundError(t *testing.T) {
 	helper.AssertErr("Error: [The tenant you specified could not be found]")
 }
 
+func TestGetTenantWithTrailingNewlineInId(t *testing.T) {
+	helper := testutils.NewAuraTestHelper(t)
+	defer helper.Close()
+
+	tenantId := "6981ace7-efe8-4f5c-b7c5-267b5162ce91"
+
+	getMockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s", tenantId), http.StatusOK, `{
+			"data": {
+				"id": "6981ace7-efe8-4f5c-b7c5-267b5162ce91",
+				"name": "Production",
+				"instance_configurations": []
+			}
+		}`)
+
+	metricsIntegrationMockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s/metrics-integration", tenantId), http.StatusBadRequest, `{
+			"errors": [
+				{
+					"message": "This tenant has no instances eligible for metrics integration",
+					"reason": "tenant-incapable-of-action"
+				}
+			]
+		}`)
+
+	helper.ExecuteCommand(fmt.Sprintf("tenant get \"%s\n\"", tenantId))
+
+	getMockHandler.AssertCalledTimes(1)
+	getMockHandler.AssertCalledWithMethod(http.MethodGet)
+	metricsIntegrationMockHandler.AssertCalledTimes(1)
+	metricsIntegrationMockHandler.AssertCalledWithMethod(http.MethodGet)
+
+	helper.AssertOutJson(`{
+		"data": {
+			"id": "6981ace7-efe8-4f5c-b7c5-267b5162ce91",
+			"instance_configurations": [],
+			"name": "Production"
+		}
+	}
+	`)
+}
+
 func TestGetTenantWithTableOutput(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()


### PR DESCRIPTION
Fixing bug described in https://github.com/neo4j/aura-cli/issues/112

Found that the newline results in the resbody being returned as HTML instead of JSON, causing an error with unmarshalling and leading to a panic.

Addressed same issue for a few other commands.