### PR TITLE
Fix newline JSON unmarshalling bug

### DIFF
--- a/.changes/unreleased/Patch-20260514-104516.yaml
+++ b/.changes/unreleased/Patch-20260514-104516.yaml
@@ -1,0 +1,3 @@
+kind: Patch
+body: 'Fix for issue #112 where a new line at the end of some commands causes a panic'
+time: 2026-05-14T10:45:16.980848+01:00

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add.go
@@ -38,7 +38,7 @@ Updating the CORS policy of a GraphQL Data API is an asynchronous operation. Use
 Adding a new allowed origin to the CORS policy of a GraphQL Data API allows browsers to make requests to the GraphQL Data API from a web app that is served from the specified origin.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			newOrigin := args[0]
+			newOrigin := strings.TrimSpace(args[0])
 
 			existingOrigins, err := getExistingOrigins(cfg, dataApiId, instanceId)
 			if err != nil {

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add_test.go
@@ -178,6 +178,48 @@ func TestAddAllowedOriginWithDuplicateOrigin(t *testing.T) {
 	helper.AssertErr(fmt.Sprintf("Error: Origin \"%s\" already exists in allowed origins\n", allowedOrigin))
 }
 
+func TestAddAllowedOriginWithTrailingNewlineInOrigin(t *testing.T) {
+	mockGetResponse := `{
+		"data": {
+			"id": "2f49c2b3",
+			"name": "my-data-api-1",
+			"status": "ready",
+			"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql",
+			"security": {
+				"cors_policy": {
+					"allowed_origins": []
+				}
+			}
+		}
+	}`
+	expectedResponse := fmt.Sprintf(`New allowed origins: ["%s"]
+{
+	"data": {
+		"id": "2f49c2b3",
+		"name": "my-data-api-1",
+		"status": "ready",
+		"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql"
+	}
+}`, allowedOrigin)
+
+	helper := testutils.NewAuraTestHelper(t)
+	defer helper.Close()
+
+	helper.SetConfigValue("aura.beta-enabled", true)
+
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
+	mockHandler.AddResponse(http.StatusAccepted, mockPatchResponse)
+
+	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin add --instance-id %s --data-api-id %s \"%s\n\"", instanceId, dataApiId, allowedOrigin))
+
+	mockHandler.AssertCalledTimes(2)
+	mockHandler.AssertCalledWithMethod(http.MethodGet)
+	mockHandler.AssertCalledWithMethod(http.MethodPatch)
+	mockHandler.AssertCalledWithBody(fmt.Sprintf("{\"security\":{\"cors_policy\":{\"allowed_origins\":[\"%s\"]}}}", allowedOrigin))
+
+	helper.AssertOut(expectedResponse)
+}
+
 func TestAddAllowedOriginWithOutputTable(t *testing.T) {
 	mockGetResponse := `{
 		"data": {

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/add_test.go
@@ -210,7 +210,7 @@ func TestAddAllowedOriginWithTrailingNewlineInOrigin(t *testing.T) {
 	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
 	mockHandler.AddResponse(http.StatusAccepted, mockPatchResponse)
 
-	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin add --instance-id %s --data-api-id %s \"%s\n\"", instanceId, dataApiId, allowedOrigin))
+	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin add --instance-id %s --data-api-id %s %s\"\n\"", instanceId, dataApiId, allowedOrigin))
 
 	mockHandler.AssertCalledTimes(2)
 	mockHandler.AssertCalledWithMethod(http.MethodGet)

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove.go
@@ -38,7 +38,7 @@ Updating the CORS policy of a GraphQL Data API is an asynchronous operation. Use
 Removing an allowed origin from the CORS policy of a GraphQL Data API means that most browsers are no longer able to make requests to the GraphQL Data API from a web app that is served from the specified origin.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			originToRemove := args[0]
+			originToRemove := strings.TrimSpace(args[0])
 
 			existingOrigins, err := getExistingOrigins(cfg, dataApiId, instanceId)
 			if err != nil {

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove_test.go
@@ -164,6 +164,49 @@ func TestRemoveAllowedOriginLastAllowedOrigin(t *testing.T) {
 	helper.AssertOut(expectedResponse)
 }
 
+func TestRemoveAllowedOriginWithTrailingNewlineInOrigin(t *testing.T) {
+	mockGetResponse := fmt.Sprintf(`{
+		"data": {
+			"id": "2f49c2b3",
+			"name": "my-data-api-1",
+			"status": "ready",
+			"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql",
+			"security": {
+				"cors_policy": {
+					"allowed_origins": ["https://test1.com", "https://test2.com", "%s"]
+				}
+			}
+		}
+	}`, allowedOrigin)
+	expectedResponse := `New allowed origins: ["https://test1.com", "https://test2.com"]
+{
+	"data": {
+		"id": "2f49c2b3",
+		"name": "my-data-api-1",
+		"status": "ready",
+		"url": "https://2f49c2b3.28be6e4d8d3e8360197cb6c1fa1d25d1.graphql.neo4j-dev.io/graphql"
+	}
+}`
+
+	helper := testutils.NewAuraTestHelper(t)
+	defer helper.Close()
+
+	helper.SetConfigValue("aura.beta-enabled", true)
+
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
+	mockHandler.AddResponse(http.StatusAccepted, mockPatchResponse)
+
+	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin remove --instance-id %s --data-api-id %s \"%s\n\"", instanceId, dataApiId, allowedOrigin))
+
+	mockHandler.AssertCalledTimes(2)
+	mockHandler.AssertCalledWithMethod(http.MethodGet)
+
+	mockHandler.AssertCalledWithMethod(http.MethodPatch)
+	mockHandler.AssertCalledWithBody("{\"security\":{\"cors_policy\":{\"allowed_origins\":[\"https://test1.com\",\"https://test2.com\"]}}}")
+
+	helper.AssertOut(expectedResponse)
+}
+
 func TestRemoveAllowedOriginWithOutputTable(t *testing.T) {
 	mockGetResponse := fmt.Sprintf(`{
 		"data": {

--- a/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove_test.go
+++ b/neo4j-cli/aura/internal/subcommands/dataapi/graphql/corspolicy/allowedorigin/remove_test.go
@@ -196,7 +196,7 @@ func TestRemoveAllowedOriginWithTrailingNewlineInOrigin(t *testing.T) {
 	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1beta5/instances/%s/data-apis/graphql/%s", instanceId, dataApiId), http.StatusOK, mockGetResponse)
 	mockHandler.AddResponse(http.StatusAccepted, mockPatchResponse)
 
-	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin remove --instance-id %s --data-api-id %s \"%s\n\"", instanceId, dataApiId, allowedOrigin))
+	helper.ExecuteCommand(fmt.Sprintf("data-api graphql cors-policy allowed-origin remove --instance-id %s --data-api-id %s %s\"\n\"", instanceId, dataApiId, allowedOrigin))
 
 	mockHandler.AssertCalledTimes(2)
 	mockHandler.AssertCalledWithMethod(http.MethodGet)

--- a/neo4j-cli/aura/internal/subcommands/deployment/delete.go
+++ b/neo4j-cli/aura/internal/subcommands/deployment/delete.go
@@ -6,6 +6,7 @@ package deployment
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/neo4j/cli/common/clicfg"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
@@ -38,7 +39,7 @@ func NewDeleteCmd(cfg *clicfg.Config) *cobra.Command {
 				return err
 			}
 
-			deploymentId := args[0]
+			deploymentId := strings.TrimSpace(args[0])
 			path := fmt.Sprintf("/organizations/%s/projects/%s/fleet-manager/deployments/%s", organizationId, projectId, deploymentId)
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/deployment/delete_test.go
+++ b/neo4j-cli/aura/internal/subcommands/deployment/delete_test.go
@@ -52,6 +52,26 @@ func TestDeleteDeploymentWithOrganizationAndProjectIdFromConfig(t *testing.T) {
 	helper.AssertOut("Deployment deleted successfully 9a1e6181-7d0b-48a2-bc2b-4250c36b5cc2")
 }
 
+func TestDeleteDeploymentWithTrailingNewlineInId(t *testing.T) {
+	helper := testutils.NewAuraTestHelper(t)
+	defer helper.Close()
+
+	organizationId := "81e4ae5c-171b-4700-b243-8d1dd34f7321"
+	projectId := "ef7faf53-fb7e-4994-8d0f-64ae56e91c42"
+	deploymentId := "9a1e6181-7d0b-48a2-bc2b-4250c36b5cc2"
+
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v2beta1/organizations/%s/projects/%s/fleet-manager/deployments/%s", organizationId, projectId, deploymentId), http.StatusNoContent, "")
+
+	helper.SetConfigValue("aura.beta-enabled", true)
+	helper.SetConfigValue("aura.output", "json")
+	helper.ExecuteCommand(fmt.Sprintf("deployment delete --organization-id %s --project-id %s \"%s\n\"", organizationId, projectId, deploymentId))
+
+	mockHandler.AssertCalledTimes(1)
+	mockHandler.AssertCalledWithMethod(http.MethodDelete)
+
+	helper.AssertOut("Deployment deleted successfully 9a1e6181-7d0b-48a2-bc2b-4250c36b5cc2")
+}
+
 func TestDeleteDeploymentWhenDeploymentDoesNotExist(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()

--- a/neo4j-cli/aura/internal/subcommands/deployment/delete_test.go
+++ b/neo4j-cli/aura/internal/subcommands/deployment/delete_test.go
@@ -64,7 +64,7 @@ func TestDeleteDeploymentWithTrailingNewlineInId(t *testing.T) {
 
 	helper.SetConfigValue("aura.beta-enabled", true)
 	helper.SetConfigValue("aura.output", "json")
-	helper.ExecuteCommand(fmt.Sprintf("deployment delete --organization-id %s --project-id %s \"%s\n\"", organizationId, projectId, deploymentId))
+	helper.ExecuteCommand(fmt.Sprintf("deployment delete --organization-id %s --project-id %s %s\"\n\"", organizationId, projectId, deploymentId))
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodDelete)

--- a/neo4j-cli/aura/internal/subcommands/deployment/get.go
+++ b/neo4j-cli/aura/internal/subcommands/deployment/get.go
@@ -6,6 +6,7 @@ package deployment
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/neo4j/cli/common/clicfg"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
@@ -39,7 +40,7 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 				return err
 			}
 
-			deploymentId := args[0]
+			deploymentId := strings.TrimSpace(args[0])
 			path := fmt.Sprintf("/organizations/%s/projects/%s/fleet-manager/deployments/%s", organizationId, projectId, deploymentId)
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/deployment/get_test.go
+++ b/neo4j-cli/aura/internal/subcommands/deployment/get_test.go
@@ -174,7 +174,7 @@ func TestGetDeploymentWithTrailingNewlineInId(t *testing.T) {
 
 	helper.SetConfigValue("aura.beta-enabled", true)
 	helper.SetConfigValue("aura.output", "json")
-	helper.ExecuteCommand(fmt.Sprintf("deployment get --organization-id=%s --project-id=%s \"%s\n\"", organizationId, projectId, deploymentId))
+	helper.ExecuteCommand(fmt.Sprintf("deployment get --organization-id=%s --project-id=%s %s\"\n\"", organizationId, projectId, deploymentId))
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodGet)

--- a/neo4j-cli/aura/internal/subcommands/deployment/get_test.go
+++ b/neo4j-cli/aura/internal/subcommands/deployment/get_test.go
@@ -140,6 +140,70 @@ func TestGetDeploymentWithOrganizationAndProjectIdFromConfig(t *testing.T) {
 	}`)
 }
 
+func TestGetDeploymentWithTrailingNewlineInId(t *testing.T) {
+	helper := testutils.NewAuraTestHelper(t)
+	defer helper.Close()
+
+	organizationId := "81e4ae5c-171b-4700-b243-8d1dd34f7321"
+	projectId := "ef7faf53-fb7e-4994-8d0f-64ae56e91c42"
+	deploymentId := "9a1e6181-7d0b-48a2-bc2b-4250c36b5cc2"
+
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v2beta1/organizations/%s/projects/%s/fleet-manager/deployments/%s", organizationId, projectId, deploymentId), http.StatusOK, `{
+		"data": {
+			"id": "9a1e6181-7d0b-48a2-bc2b-4250c36b5cc2",
+			"name": "Test Deployment",
+			"status": "running",
+			"created_by": "941d32f6-6abf-42d7-beb8-012341376dc6",
+			"dbms": {
+				"edition": "enterprise",
+				"metric_collection_enabled": true,
+				"packaging": "PACKAGING"
+			},
+			"token": {
+				"id": "941d32f6-6abf-42d7-beb8-012341376dc6",
+				"claimed_time": "CLAIMED_BY",
+				"expiry_time": "EXPIRY_TIME",
+				"last_used_time": "LAST_USED",
+				"release_time": "RELEASE_TIME",
+				"auto_rotated": true,
+				"created_by": "941d32f6-6abf-42d7-beb8-012341376dc6",
+				"creation_time": "CREATION_TIME"
+			}
+		}
+	}`)
+
+	helper.SetConfigValue("aura.beta-enabled", true)
+	helper.SetConfigValue("aura.output", "json")
+	helper.ExecuteCommand(fmt.Sprintf("deployment get --organization-id=%s --project-id=%s \"%s\n\"", organizationId, projectId, deploymentId))
+
+	mockHandler.AssertCalledTimes(1)
+	mockHandler.AssertCalledWithMethod(http.MethodGet)
+
+	helper.AssertOutJson(`{
+		"data": {
+			"created_by": "941d32f6-6abf-42d7-beb8-012341376dc6",
+			"dbms": {
+				"edition": "enterprise",
+				"metric_collection_enabled": true,
+				"packaging": "PACKAGING"
+			},
+			"id": "9a1e6181-7d0b-48a2-bc2b-4250c36b5cc2",
+			"name": "Test Deployment",
+			"status": "running",
+			"token": {
+				"auto_rotated": true,
+				"claimed_time": "CLAIMED_BY",
+				"created_by": "941d32f6-6abf-42d7-beb8-012341376dc6",
+				"creation_time": "CREATION_TIME",
+				"expiry_time": "EXPIRY_TIME",
+				"id": "941d32f6-6abf-42d7-beb8-012341376dc6",
+				"last_used_time": "LAST_USED",
+				"release_time": "RELEASE_TIME"
+			}
+		}
+	}`)
+}
+
 func TestGetDeploymentWithTableOutput(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()

--- a/neo4j-cli/aura/internal/subcommands/import/job/cancel.go
+++ b/neo4j-cli/aura/internal/subcommands/import/job/cancel.go
@@ -6,6 +6,7 @@ package job
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/neo4j/cli/common/clicfg"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
@@ -39,7 +40,7 @@ func NewCancelCommand(cfg *clicfg.Config) *cobra.Command {
 				return err
 			}
 
-			jobId = args[0]
+			jobId = strings.TrimSpace(args[0])
 			path := fmt.Sprintf("/organizations/%s/projects/%s/import/jobs/%s/cancellation", organizationId, projectId, jobId)
 			resBody, statusCode, err := api.MakeRequest(cfg, path, &api.RequestConfig{
 				Method:  http.MethodPost,

--- a/neo4j-cli/aura/internal/subcommands/import/job/cancel_test.go
+++ b/neo4j-cli/aura/internal/subcommands/import/job/cancel_test.go
@@ -26,7 +26,6 @@ func TestCancelImportJob(t *testing.T) {
 	`, jobId))
 
 	helper.SetConfigValue("aura.beta-enabled", true)
-
 	helper.ExecuteCommand(fmt.Sprintf("import job cancel --organization-id=%s --project-id=%s %s", organizationId, projectId, jobId))
 
 	mockHandler.AssertCalledTimes(1)
@@ -57,6 +56,34 @@ func TestCancelImportJobWithOrganizationAndProjectIdFromConfig(t *testing.T) {
 	helper.SetConfigValue("aura.beta-enabled", true)
 	helper.SetDefaultProjectInConfig(organizationId, projectId)
 	helper.ExecuteCommand(fmt.Sprintf("import job cancel %s", jobId))
+
+	mockHandler.AssertCalledTimes(1)
+	mockHandler.AssertCalledWithMethod(http.MethodPost)
+
+	helper.AssertErr("")
+	helper.AssertOutJson(fmt.Sprintf(`
+		{
+			"data": {"id": "%s"}
+		}
+	`, jobId))
+}
+
+func TestCancelImportJobWithTrailingNewlineInId(t *testing.T) {
+	organizationId := "f607bebe-0cc0-4166-b60c-b4eed69ee7ee"
+	projectId := "f607bebe-0cc0-4166-b60c-b4eed69ee7ee"
+	jobId := "87d485b4-73fc-4a7f-bb03-720f4672947e"
+
+	helper := testutils.NewAuraTestHelper(t)
+	defer helper.Close()
+
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v2beta1/organizations/%s/projects/%s/import/jobs/%s/cancellation", organizationId, projectId, jobId), http.StatusOK, fmt.Sprintf(`
+		{
+			"data": {"id": "%s"}
+		}
+	`, jobId))
+
+	helper.SetConfigValue("aura.beta-enabled", true)
+	helper.ExecuteCommand(fmt.Sprintf("import job cancel --organization-id=%s --project-id=%s \"%s\n\"", organizationId, projectId, jobId))
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodPost)
@@ -141,7 +168,6 @@ func TestCancelImportJobError(t *testing.T) {
 			mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v2beta1/organizations/%s/projects/%s/import/jobs/%s/cancellation", organizationId, projectId, jobId), testCase.statusCode, testCase.returnBody)
 
 			helper.SetConfigValue("aura.beta-enabled", true)
-
 			helper.ExecuteCommand(testCase.executeCommand)
 
 			mockHandler.AssertCalledTimes(testCase.expectedCalledTimes)

--- a/neo4j-cli/aura/internal/subcommands/import/job/cancel_test.go
+++ b/neo4j-cli/aura/internal/subcommands/import/job/cancel_test.go
@@ -83,7 +83,7 @@ func TestCancelImportJobWithTrailingNewlineInId(t *testing.T) {
 	`, jobId))
 
 	helper.SetConfigValue("aura.beta-enabled", true)
-	helper.ExecuteCommand(fmt.Sprintf("import job cancel --organization-id=%s --project-id=%s \"%s\n\"", organizationId, projectId, jobId))
+	helper.ExecuteCommand(fmt.Sprintf("import job cancel --organization-id=%s --project-id=%s %s\"\n\"", organizationId, projectId, jobId))
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodPost)

--- a/neo4j-cli/aura/internal/subcommands/import/job/get.go
+++ b/neo4j-cli/aura/internal/subcommands/import/job/get.go
@@ -6,6 +6,7 @@ package job
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/neo4j/cli/common/clicfg"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
@@ -41,7 +42,7 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 				return err
 			}
 
-			jobId = args[0]
+			jobId = strings.TrimSpace(args[0])
 			path := fmt.Sprintf("/organizations/%s/projects/%s/import/jobs/%s", organizationId, projectId, jobId)
 
 			resBody, statusCode, err := api.MakeRequest(cfg, path, &api.RequestConfig{

--- a/neo4j-cli/aura/internal/subcommands/import/job/get_test.go
+++ b/neo4j-cli/aura/internal/subcommands/import/job/get_test.go
@@ -665,6 +665,63 @@ func TestGetImportJobByIdWithOrganizationAndProjectIdFromConfig(t *testing.T) {
 	`)
 }
 
+func TestGetImportJobWithTrailingNewlineInId(t *testing.T) {
+	organizationId := "f607bebe-0cc0-4166-b60c-b4eed69ee7ee"
+	projectId := "f607bebe-0cc0-4166-b60c-b4eed69ee7ee"
+	jobId := "87d485b4-73fc-4a7f-bb03-720f4672947e"
+
+	helper := testutils.NewAuraTestHelper(t)
+	defer helper.Close()
+
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v2beta1/organizations/%s/projects/%s/import/jobs/%s", organizationId, projectId, jobId), http.StatusOK, `{
+    "data": {
+        "id": "87d485b4-73fc-4a7f-bb03-720f4672947e",
+        "import_type": "cloud",
+        "info": {
+            "state": "Completed",
+            "start_time": "2025-08-15T13:12:51Z",
+            "completion_time": "2025-08-15T13:15:19Z",
+            "exit_status": {
+                "state": "Cancelled",
+                "message": "Cancelled"
+            },
+            "cancellation_requested_time": "2025-08-15T13:15:19.655209Z",
+            "submitted_time": "2025-08-15T13:12:50.499797Z",
+            "last_update_time": "2025-08-18T12:25:53.469873Z",
+            "percentage_complete": 95.23
+        },
+        "data_source": {
+            "id": "177216b3-49b9-4e24-a414-a9ecbb448c53",
+            "type": "postgresql",
+            "name": "AWS_POSTGRES_FLIGHTS"
+        },
+        "aura_target": {
+            "db_id": "07e49cf5",
+            "project_id": "f607bebe-0cc0-4166-b60c-b4eed69ee7ee"
+        },
+        "user_id": "f607bebe-0cc0-4166-b60c-b4eed69ee7ee"
+    }}`)
+
+	helper.SetConfigValue("aura.beta-enabled", true)
+	helper.ExecuteCommand(fmt.Sprintf("import job get --organization-id=%s --project-id=%s --output=table \"%s\n\"", organizationId, projectId, jobId))
+
+	mockHandler.AssertCalledTimes(1)
+	mockHandler.AssertCalledWithMethod(http.MethodGet)
+	mockHandler.AssertCalledWithQueryParam("progress", "false")
+	helper.AssertOut(`
+┌──────────────────────────────────────┬─────────────┬────────────┬────────────────────────┬──────────────────────────┬──────────────────────┬───────────────────┐
+│ ID                                   │ IMPORT_TYPE │ INFO:STATE │ INFO:EXIT_STATUS:STATE │ INFO:PERCENTAGE_COMPLETE │ DATA_SOURCE:NAME     │ AURA_TARGET:DB_ID │
+├──────────────────────────────────────┼─────────────┼────────────┼────────────────────────┼──────────────────────────┼──────────────────────┼───────────────────┤
+│ 87d485b4-73fc-4a7f-bb03-720f4672947e │ cloud       │ Completed  │ Cancelled              │ 95.23                    │ AWS_POSTGRES_FLIGHTS │ 07e49cf5          │
+└──────────────────────────────────────┴─────────────┴────────────┴────────────────────────┴──────────────────────────┴──────────────────────┴───────────────────┘
+┌──────────────────────────┐
+│ INFO:EXIT_STATUS:MESSAGE │
+├──────────────────────────┤
+│ Cancelled                │
+└──────────────────────────┘
+	`)
+}
+
 func TestGetImportJobError(t *testing.T) {
 	organizationId := "f607bebe-0cc0-4166-b60c-b4eed69ee7ee"
 	projectId := "f607bebe-0cc0-4166-b60c-b4eed69ee7ee"

--- a/neo4j-cli/aura/internal/subcommands/import/job/get_test.go
+++ b/neo4j-cli/aura/internal/subcommands/import/job/get_test.go
@@ -703,7 +703,7 @@ func TestGetImportJobWithTrailingNewlineInId(t *testing.T) {
     }}`)
 
 	helper.SetConfigValue("aura.beta-enabled", true)
-	helper.ExecuteCommand(fmt.Sprintf("import job get --organization-id=%s --project-id=%s --output=table \"%s\n\"", organizationId, projectId, jobId))
+	helper.ExecuteCommand(fmt.Sprintf("import job get --organization-id=%s --project-id=%s --output=table %s\"\n\"", organizationId, projectId, jobId))
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodGet)

--- a/neo4j-cli/aura/internal/subcommands/instance/get.go
+++ b/neo4j-cli/aura/internal/subcommands/instance/get.go
@@ -6,6 +6,7 @@ package instance
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -21,7 +22,7 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 		Long:  "This endpoint returns details about a specific Aura Instance.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			instanceId := args[0]
+			instanceId := strings.TrimSpace(args[0])
 			path := fmt.Sprintf("/instances/%s", instanceId)
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/instance/get_test.go
+++ b/neo4j-cli/aura/internal/subcommands/instance/get_test.go
@@ -58,6 +58,50 @@ func TestGetInstance(t *testing.T) {
 	}`)
 }
 
+func TestGetInstanceWithTrailingNewlineInId(t *testing.T) {
+	helper := testutils.NewAuraTestHelper(t)
+	defer helper.Close()
+
+	instanceId := "2f49c2b3"
+
+	mockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/instances/%s", instanceId), http.StatusOK, `{
+			"data": {
+				"id": "2f49c2b3",
+				"name": "Production",
+				"status": "running",
+				"tenant_id": "YOUR_TENANT_ID",
+				"cloud_provider": "gcp",
+				"connection_url": "YOUR_CONNECTION_URL",
+				"metrics_integration_url": "YOUR_METRICS_INTEGRATION_ENDPOINT",
+				"region": "europe-west1",
+				"type": "enterprise-db",
+				"memory": "8GB",
+				"storage": "16GB"
+			}
+		}`)
+
+	helper.ExecuteCommand(fmt.Sprintf("instance get \"%s\n\"", instanceId))
+
+	mockHandler.AssertCalledTimes(1)
+	mockHandler.AssertCalledWithMethod(http.MethodGet)
+
+	helper.AssertOutJson(`{
+	  "data": {
+		"cloud_provider": "gcp",
+		"connection_url": "YOUR_CONNECTION_URL",
+		"id": "2f49c2b3",
+		"memory": "8GB",
+		"metrics_integration_url": "YOUR_METRICS_INTEGRATION_ENDPOINT",
+		"name": "Production",
+		"region": "europe-west1",
+		"status": "running",
+		"storage": "16GB",
+		"tenant_id": "YOUR_TENANT_ID",
+		"type": "enterprise-db"
+	  }
+	}`)
+}
+
 func TestGetEnterpriseInstanceWithTableOutput(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()

--- a/neo4j-cli/aura/internal/subcommands/instance/get_test.go
+++ b/neo4j-cli/aura/internal/subcommands/instance/get_test.go
@@ -80,7 +80,7 @@ func TestGetInstanceWithTrailingNewlineInId(t *testing.T) {
 			}
 		}`)
 
-	helper.ExecuteCommand(fmt.Sprintf("instance get \"%s\n\"", instanceId))
+	helper.ExecuteCommand(fmt.Sprintf("instance get %s\"\n\"", instanceId))
 
 	mockHandler.AssertCalledTimes(1)
 	mockHandler.AssertCalledWithMethod(http.MethodGet)

--- a/neo4j-cli/aura/internal/subcommands/instance/overwrite.go
+++ b/neo4j-cli/aura/internal/subcommands/instance/overwrite.go
@@ -6,6 +6,7 @@ package instance
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/neo4j/cli/common/clicfg"
 	"github.com/neo4j/cli/neo4j-cli/aura/internal/api"
@@ -36,7 +37,7 @@ If only --source-instance-id is provided, a new snapshot of that instance is cre
 		`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			instanceId := args[0]
+			instanceId := strings.TrimSpace(args[0])
 			path := fmt.Sprintf("/instances/%s/overwrite", instanceId)
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/instance/overwrite_test.go
+++ b/neo4j-cli/aura/internal/subcommands/instance/overwrite_test.go
@@ -53,6 +53,48 @@ func TestOverwriteFromInstance(t *testing.T) {
 	}`)
 }
 
+func TestOverwriteWithTrailingNewlineInId(t *testing.T) {
+	helper := testutils.NewAuraTestHelper(t)
+	defer helper.Close()
+
+	instanceId := "2f49c2b3"
+	sourceId := "191b0da2"
+
+	postMock := helper.NewRequestHandlerMock(fmt.Sprintf("POST /v1/instances/%s/overwrite", instanceId), http.StatusAccepted, `{
+		"data": {
+		  "id": "2f49c2b3",
+		  "name": "Production",
+		  "status": "overwriting",
+		  "connection_url": "YOUR_CONNECTION_URL",
+		  "tenant_id": "YOUR_TENANT_ID",
+		  "cloud_provider": "gcp",
+		  "memory": "8GB",
+		  "region": "europe-west1",
+		  "type": "enterprise-db"
+		}
+	  }`)
+
+	helper.ExecuteCommand(fmt.Sprintf("instance overwrite --source-instance-id %s \"%s\n\"", sourceId, instanceId))
+	postMock.AssertCalledTimes(1)
+	postMock.AssertCalledWithBody(`{
+		"source_instance_id": "191b0da2"
+	  }`)
+
+	helper.AssertOutJson(`{
+	  "data": {
+		"cloud_provider": "gcp",
+		"connection_url": "YOUR_CONNECTION_URL",
+		"id": "2f49c2b3",
+		"memory": "8GB",
+		"name": "Production",
+		"region": "europe-west1",
+		"status": "overwriting",
+		"tenant_id": "YOUR_TENANT_ID",
+		"type": "enterprise-db"
+	  }
+	}`)
+}
+
 func TestOverwriteFromSnapshot(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()

--- a/neo4j-cli/aura/internal/subcommands/instance/overwrite_test.go
+++ b/neo4j-cli/aura/internal/subcommands/instance/overwrite_test.go
@@ -74,7 +74,7 @@ func TestOverwriteWithTrailingNewlineInId(t *testing.T) {
 		}
 	  }`)
 
-	helper.ExecuteCommand(fmt.Sprintf("instance overwrite --source-instance-id %s \"%s\n\"", sourceId, instanceId))
+	helper.ExecuteCommand(fmt.Sprintf("instance overwrite --source-instance-id %s %s\"\n\"", sourceId, instanceId))
 	postMock.AssertCalledTimes(1)
 	postMock.AssertCalledWithBody(`{
 		"source_instance_id": "191b0da2"

--- a/neo4j-cli/aura/internal/subcommands/tenant/get.go
+++ b/neo4j-cli/aura/internal/subcommands/tenant/get.go
@@ -6,6 +6,7 @@ package tenant
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -22,7 +23,7 @@ func NewGetCmd(cfg *clicfg.Config) *cobra.Command {
 		Long:  "This subcommand returns details about a specific Aura Tenant.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			tenantId := args[0]
+			tenantId := strings.TrimSpace(args[0])
 			path := fmt.Sprintf("/tenants/%s", tenantId)
 
 			cmd.SilenceUsage = true

--- a/neo4j-cli/aura/internal/subcommands/tenant/get_test.go
+++ b/neo4j-cli/aura/internal/subcommands/tenant/get_test.go
@@ -112,6 +112,46 @@ func TestGetTenantNotFoundError(t *testing.T) {
 	helper.AssertErr("Error: [The tenant you specified could not be found]")
 }
 
+func TestGetTenantWithTrailingNewlineInId(t *testing.T) {
+	helper := testutils.NewAuraTestHelper(t)
+	defer helper.Close()
+
+	tenantId := "6981ace7-efe8-4f5c-b7c5-267b5162ce91"
+
+	getMockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s", tenantId), http.StatusOK, `{
+			"data": {
+				"id": "6981ace7-efe8-4f5c-b7c5-267b5162ce91",
+				"name": "Production",
+				"instance_configurations": []
+			}
+		}`)
+
+	metricsIntegrationMockHandler := helper.NewRequestHandlerMock(fmt.Sprintf("/v1/tenants/%s/metrics-integration", tenantId), http.StatusBadRequest, `{
+			"errors": [
+				{
+					"message": "This tenant has no instances eligible for metrics integration",
+					"reason": "tenant-incapable-of-action"
+				}
+			]
+		}`)
+
+	helper.ExecuteCommand(fmt.Sprintf("tenant get \"%s\n\"", tenantId))
+
+	getMockHandler.AssertCalledTimes(1)
+	getMockHandler.AssertCalledWithMethod(http.MethodGet)
+	metricsIntegrationMockHandler.AssertCalledTimes(1)
+	metricsIntegrationMockHandler.AssertCalledWithMethod(http.MethodGet)
+
+	helper.AssertOutJson(`{
+		"data": {
+			"id": "6981ace7-efe8-4f5c-b7c5-267b5162ce91",
+			"instance_configurations": [],
+			"name": "Production"
+		}
+	}
+	`)
+}
+
 func TestGetTenantWithTableOutput(t *testing.T) {
 	helper := testutils.NewAuraTestHelper(t)
 	defer helper.Close()

--- a/neo4j-cli/aura/internal/subcommands/tenant/get_test.go
+++ b/neo4j-cli/aura/internal/subcommands/tenant/get_test.go
@@ -135,7 +135,7 @@ func TestGetTenantWithTrailingNewlineInId(t *testing.T) {
 			]
 		}`)
 
-	helper.ExecuteCommand(fmt.Sprintf("tenant get \"%s\n\"", tenantId))
+	helper.ExecuteCommand(fmt.Sprintf("tenant get %s\"\n\"", tenantId))
 
 	getMockHandler.AssertCalledTimes(1)
 	getMockHandler.AssertCalledWithMethod(http.MethodGet)


### PR DESCRIPTION
Fixing bug described in https://github.com/neo4j/aura-cli/issues/112

Found that the newline results in the resbody being returned as HTML instead of JSON, causing an error with unmarshalling and leading to a panic.

Addressed same issue for a few other commands.