### PR TITLE
Pin CI Go version consistently across workflows

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -17,7 +17,7 @@ jobs:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
             - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
               with:
-                  go-version: "1.26.6"
+                  go-version: "1.26.2"
             - name: Install addlicense
               run: go install github.com/google/addlicense@latest
             - name: Run addlicense

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: "stable"
+          go-version: "1.26.2"
 
       - name: Get the latest version
         id: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
               with:
-                  go-version: "stable"
+                  go-version: "1.26.2"
 
             - name: Build
               run: go build -v ./...

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,25 @@
         {
             "matchUpdateTypes": ["minor", "patch"],
             "groupName": "minor-and-patch"
+        },
+        {
+            "matchDepNames": ["go"],
+            "matchDatasources": ["golang-version"],
+            "groupName": "go version",
+            "description": "Keep go.mod's go directive and the CI-pinned go-version strings on the same version"
+        }
+    ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "description": "Keep the go.mod directive and the CI-pinned go-version strings on the same version",
+            "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/", "/^go\\.mod$/"],
+            "matchStrings": [
+                "go-version: \"(?<currentValue>.*?)\"\\s",
+                "\\ngo (?<currentValue>\\d+\\.\\d+\\.\\d+)\\n"
+            ],
+            "depNameTemplate": "go",
+            "datasourceTemplate": "golang-version"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- test.yml, release.yml, and license.yml were pinning three different Go versions ("stable" resolving to 1.27.0, and 1.26.6) — `go-version: "stable"` resolves to a release newer than staticcheck 2026.1's bundled export-data parser supports (format version 4 vs. max supported 2), which is what was actually failing CI on #191. Pin all three workflows to 1.26.2, verified locally against staticcheck 2026.1.
- Add a Renovate custom manager that tracks the pinned `go-version` strings alongside go.mod's `go` directive under the same `golang-version` datasource/dep name, and group them so they bump together in one PR instead of drifting apart again.

Split out of #191 per review feedback there.